### PR TITLE
feat(slides): render full woven DfgEvolution figure (#62)

### DIFF
--- a/slides/template/components/DfgEvolution.test.js
+++ b/slides/template/components/DfgEvolution.test.js
@@ -65,4 +65,104 @@ describe('DfgEvolution — frame choreography', () => {
     await wrapper.setProps({ frame: 3 })
     expect(allForecastFlags().every((f) => f === 'true')).toBe(true)
   })
+
+  it('renders every DFG node, with activity labels shown', () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    // 8 nodes: start ●, 6 activities, end ■.
+    expect(wrapper.findAll('[data-node]')).toHaveLength(8)
+    // A representative activity label is rendered as text.
+    expect(wrapper.get('[data-node="sent"]').text()).toContain('Sent')
+  })
+
+  it('recolours edges: ink/neutral when observed, accent + dashed on the forecast frame', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const hero = () => wrapper.get('[data-edge="sent__cancelled"]')
+    const plain = () => wrapper.get('[data-edge="created__sent"]')
+
+    const isDashed = (el) => /[1-9]/.test(el.attributes('stroke-dasharray') || '0')
+
+    // observed: hero drawn in ink, chain edge neutral, neither dashed
+    expect(hero().attributes('stroke')).toBe('#0f172a')
+    expect(plain().attributes('stroke')).toBe('#475569')
+    expect(isDashed(hero())).toBe(false)
+
+    // forecast: every edge recoloured to the single accent and dashed
+    await wrapper.setProps({ frame: 3 })
+    expect(hero().attributes('stroke')).toBe('#1d4ed8')
+    expect(plain().attributes('stroke')).toBe('#1d4ed8')
+    expect(isDashed(hero())).toBe(true)
+  })
+
+  it('labels the hero edge with its weight, and the forecast vs held-out truth', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const label = () => wrapper.get('[data-testid="hero-label"]').text()
+
+    const observed = ['346', '314', '316'] // t₁..t₃ raw weekly frequency
+    for (let i = 0; i < observed.length; i++) {
+      await wrapper.setProps({ frame: i })
+      expect(label()).toBe(observed[i])
+    }
+    // forecast frame announces the prediction and the held-out truth
+    await wrapper.setProps({ frame: 3 })
+    expect(label()).toContain('316')
+    expect(label()).toContain('315')
+  })
+
+  it('shows the held-out-truth ghost only on the forecast frame, scaled to the truth weight', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const ghost = () => wrapper.find('[data-testid="hero-ghost"]')
+
+    for (const i of [0, 1, 2]) {
+      await wrapper.setProps({ frame: i })
+      expect(ghost().exists()).toBe(false)
+    }
+    await wrapper.setProps({ frame: 3 })
+    expect(ghost().exists()).toBe(true)
+    // ghost stroke-width tracks the held-out truth weight (sent__cancelled truth = 315)
+    expect(Number(ghost().attributes('stroke-width'))).toBeCloseTo(expectedWidth(315), 2)
+  })
+
+  it('always shows workflow steps ①②③, never leaking the reserved term "window"', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    for (const i of [0, 1, 2, 3]) {
+      await wrapper.setProps({ frame: i })
+      for (const n of [1, 2, 3]) {
+        const step = wrapper.find(`[data-testid="step-${n}"]`)
+        expect(step.exists()).toBe(true)
+        expect(step.text().toLowerCase()).not.toContain('window')
+      }
+    }
+  })
+
+  it('slides the event-log band right one constant week-step per frame', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const translateX = () => {
+      const t = wrapper.get('[data-testid="log-band"]').attributes('transform')
+      return Number(t.match(/translate\(\s*([-\d.]+)/)[1])
+    }
+    await wrapper.setProps({ frame: 0 })
+    expect(translateX()).toBe(0)
+    await wrapper.setProps({ frame: 1 })
+    const step = translateX()
+    expect(step).toBeGreaterThan(0)
+    for (const i of [2, 3]) {
+      await wrapper.setProps({ frame: i })
+      expect(translateX()).toBeCloseTo(i * step, 5)
+    }
+  })
+
+  it('accumulates the observed sparkline and draws the dashed forecast segment only at the end', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const obsCount = () =>
+      wrapper.get('[data-testid="spark-line"]').attributes('points').trim().split(/\s+/).length
+    const forecastSeg = () => wrapper.find('[data-testid="spark-forecast"]')
+
+    // observed polyline grows one point per observed frame; the forecast point is NOT on it
+    const expectedObs = [1, 2, 3, 3] // t₁..t₃ observed; t₄ forecast keeps the 3 observed
+    for (let i = 0; i < 4; i++) {
+      await wrapper.setProps({ frame: i })
+      expect(obsCount()).toBe(expectedObs[i])
+      expect(forecastSeg().exists()).toBe(i === 3)
+    }
+  })
 })

--- a/slides/template/components/DfgEvolution.vue
+++ b/slides/template/components/DfgEvolution.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { dfgData } from './dfgData.js'
 import { frameState } from './dfgFrameState.js'
+import { edgeGeometry, sparkScale } from './dfgGeometry.js'
 
 // `frame` is the master index; slice #3 will bind it to Slidev v-click.
 const props = defineProps({
@@ -9,34 +10,296 @@ const props = defineProps({
 })
 
 const state = computed(() => frameState(dfgData, props.frame))
+
+// Frame-independent trimmed geometry [x1,y1,x2,y2] for every edge, keyed by edge id.
+const edgeGeo = edgeGeometry(dfgData.nodes, dfgData.edges)
+
+// Workflow captions woven under each part of the figure (per render_diagram.js STEPS).
+// "weekly sublog" / "weekly snapshot" wording avoids the reserved term "window" (ER only).
+const STEPS = [
+  '① Event log → weekly sublog',
+  '② Each week → a time-indexed DFG',
+  '③ Each DF edge → a univariate time series',
+  '④ Forecast next week → forecasted DFG',
+]
+
+// Event-log slice motif (per render_diagram.js buildLog). The log is tiled into one column-
+// pair per week; a dashed band slides right one week per frame, so each click visibly grabs a
+// later time-slice of the log.
+const LOG = (() => {
+  const rows = 6, sliceCols = 2, n = dfgData.frames.length
+  const cols = sliceCols * n
+  const bw = 12, bh = 11, x0 = 6, y0 = 18, gx = 2.4, gy = 4
+  const colStep = bw + gx
+  const cells = []
+  for (let r = 0; r < rows; r++)
+    for (let c = 0; c < cols; c++)
+      cells.push({ x: x0 + c * colStep, y: y0 + r * (bh + gy) })
+  return {
+    rows, bw, bh, x0, y0, gy, cells,
+    W: x0 + cols * colStep + 6,
+    H: y0 + rows * (bh + gy) + 18,
+    weekStep: sliceCols * colStep,
+    bandW: sliceCols * colStep - gx + 4,
+    bandH: rows * (bh + gy) + 2,
+    labelY: y0 + rows * (bh + gy) + 12,
+  }
+})()
+
+// The week the sliding band currently covers (e.g. "Oct 02"; the forecast week drops its tag).
+const weekLabel = computed(() =>
+  (dfgData.frames[props.frame].label.split(' · ')[1] || 'week').replace(' (forecast)', ''),
+)
+
+// Hero-edge sparkline geometry (per render_diagram.js buildSpark). Frame-independent scales;
+// the data-centred y-range shows the gentle weekly wiggle without faking a dramatic drift.
+const SPARK = (() => {
+  const dims = { W: 200, H: 96, padL: 26, padR: 12, padT: 12, padB: 20 }
+  const vals = dfgData.frames.map((f) => f.weights[dfgData.hero])
+  const { X, Y } = sparkScale(vals, dims)
+  return { ...dims, vals, X, Y, n: dfgData.frames.length }
+})()
+
+// Accumulating sparkline state for the current frame: observed polyline (forecast point is
+// NOT on it), the dashed forecast segment (last frame only), dots, and the value readout.
+const spark = computed(() => {
+  const i = props.frame
+  const { vals, X, Y, n } = SPARK
+  const obs = []
+  const dots = []
+  for (let k = 0; k <= i; k++) {
+    const isF = dfgData.frames[k].kind === 'forecast'
+    dots.push({ cx: X(k), cy: Y(vals[k]), isF })
+    if (!isF) obs.push(`${X(k)},${Y(vals[k])}`)
+  }
+  const isLastForecast = i === n - 1 && dfgData.frames[i].kind === 'forecast'
+  const forecastPoints = isLastForecast
+    ? `${X(i - 1)},${Y(vals[i - 1])} ${X(i)},${Y(vals[i])}`
+    : null
+  const valLabel = isLastForecast
+    ? { x: X(i) - 2, y: Y(vals[i]) - 6, anchor: 'end', fill: dfgData.accent, text: `≈${vals[i]}` }
+    : { x: X(i) + 5, y: Y(vals[i]) - 5, anchor: 'start', fill: '#475569', text: `${vals[i]}` }
+  return { obsPoints: obs.join(' '), forecastPoints, dots, valLabel }
+})
 </script>
 
 <template>
-  <!-- Minimal scaffold: stable hooks only. The full woven figure lands in slice #62. -->
-  <div data-testid="dfg-evolution">
+  <!-- Woven full-width figure: one unified picture that both narrates the PMF workflow
+       (log → DFG → per-edge series → forecast) and lands the capability to forecast next
+       week's DFG, with each workflow step labelled at its part of the diagram. -->
+  <div data-testid="dfg-evolution" class="dfg-evolution">
+    <div class="woven-grid">
+      <!-- ① event-log slice -->
+      <div class="wcol wcol-log">
+        <div class="slot">
     <!-- Event-log slice band: slides right one week per frame to grab a later time-slice. -->
-    <div data-testid="log-slice" :data-slice-index="state.sliceIndex" />
+    <svg
+      data-testid="log-slice" :data-slice-index="state.sliceIndex"
+      :viewBox="`0 0 ${LOG.W} ${LOG.H}`" width="100%" height="100%"
+    >
+      <text :x="LOG.x0" y="10" font-size="9" fill="#64748b" font-weight="600">event log</text>
+      <rect
+        v-for="(cell, k) in LOG.cells" :key="k"
+        :x="cell.x" :y="cell.y" :width="LOG.bw" :height="LOG.bh" rx="1.5" fill="#e2e8f0"
+      />
+      <g data-testid="log-band" :transform="`translate(${state.sliceIndex * LOG.weekStep},0)`">
+        <rect
+          :x="LOG.x0 - 2" :y="LOG.y0 - 4" :width="LOG.bandW" :height="LOG.bandH" rx="2"
+          :fill="dfgData.accent" fill-opacity="0.12" :stroke="dfgData.accent"
+          stroke-width="1.2" stroke-dasharray="3 2"
+        />
+        <text
+          :x="LOG.x0 - 2 + LOG.bandW / 2" :y="LOG.labelY" text-anchor="middle"
+          font-size="9" font-weight="700" :fill="dfgData.accent"
+        >{{ weekLabel }}</text>
+      </g>
+    </svg>
+        </div>
+        <div data-testid="step-1" class="cap">{{ STEPS[0] }}</div>
+      </div>
+
+      <div class="warrow">→</div>
+
+      <!-- ② time-indexed DFG -->
+      <div class="wcol wcol-dfg">
+        <div class="slot">
     <svg viewBox="0 0 100 104" width="100%" height="100%">
+      <defs>
+        <marker
+          v-for="m in [{ id: 'arrow', col: '#475569' }, { id: 'arrowA', col: dfgData.accent }]"
+          :key="m.id" :id="m.id" viewBox="0 0 10 10" refX="8" refY="5"
+          markerWidth="3.4" markerHeight="3.4" orient="auto-start-reverse"
+          markerUnits="userSpaceOnUse"
+        >
+          <path d="M0,0 L10,5 L0,10 z" :fill="m.col" />
+        </marker>
+      </defs>
       <line
         v-for="edge in dfgData.edges"
         :key="edge.id"
         :data-edge="edge.id"
         :data-forecast="state.edges[edge.id].isForecast"
+        :x1="edgeGeo[edge.id][0]" :y1="edgeGeo[edge.id][1]"
+        :x2="edgeGeo[edge.id][2]" :y2="edgeGeo[edge.id][3]"
+        fill="none" stroke-linecap="round"
         :stroke-width="state.edges[edge.id].strokeWidth"
-        :stroke="state.edges[edge.id].isForecast ? dfgData.accent : '#475569'"
+        :stroke="state.edges[edge.id].stroke"
+        :marker-end="`url(#${state.edges[edge.id].marker})`"
+        :stroke-dasharray="state.edges[edge.id].dashed ? '2.4 1.8' : '0'"
       />
+      <!-- Held-out-truth ghost over the hero edge, forecast frame only. -->
+      <line
+        v-if="state.heroGhost.visible"
+        data-testid="hero-ghost"
+        :x1="edgeGeo[dfgData.hero][0]" :y1="edgeGeo[dfgData.hero][1]"
+        :x2="edgeGeo[dfgData.hero][2]" :y2="edgeGeo[dfgData.hero][3]"
+        fill="none" stroke="#94a3b8" stroke-linecap="round" opacity="0.6"
+        :stroke-width="state.heroGhost.strokeWidth"
+      />
+      <!-- Hero-edge weight readout, offset from the edge midpoint. -->
+      <text
+        data-testid="hero-label"
+        :x="(edgeGeo[dfgData.hero][0] + edgeGeo[dfgData.hero][2]) / 2 + 6"
+        :y="(edgeGeo[dfgData.hero][1] + edgeGeo[dfgData.hero][3]) / 2 - 1"
+        font-size="3.4" font-weight="700" :fill="state.heroLabel.fill"
+      >{{ state.heroLabel.text }}</text>
+      <!-- Nodes drawn above edges. Activity = labelled rect; start ● / end ■. -->
+      <g v-for="node in dfgData.nodes" :key="node.id" :data-node="node.id">
+        <template v-if="node.kind === 'activity'">
+          <rect
+            :x="node.x - 10.5" :y="node.y - 3.6" width="21" height="7.2" rx="2.2"
+            fill="#ffffff" stroke="#cbd5e1" stroke-width="0.5"
+          />
+          <text
+            :x="node.x" :y="node.y + 1.3" text-anchor="middle"
+            font-size="3.4" fill="#0f172a"
+          >{{ node.label }}</text>
+        </template>
+        <circle
+          v-else-if="node.kind === 'start'"
+          :cx="node.x" :cy="node.y" r="3.4" fill="#0f172a"
+        />
+        <rect
+          v-else
+          :x="node.x - 3" :y="node.y - 3" width="6" height="6" rx="0.8" fill="#0f172a"
+        />
+      </g>
     </svg>
-    <!-- Accumulating hero-edge sparkline: one point per observed/forecast frame so far. -->
-    <svg data-testid="sparkline" viewBox="0 0 100 30" width="100%">
+        </div>
+        <div data-testid="step-2" class="cap">{{ STEPS[1] }}</div>
+      </div>
+
+      <div class="warrow">→</div>
+
+      <!-- ③ per-edge time series -->
+      <div class="wcol wcol-spark">
+        <div class="spark-title">O_Sent → O_Cancelled, per week</div>
+        <div class="slot slot-spark">
+    <!-- Accumulating hero-edge sparkline: observed line grows one point per frame; the
+         held-out forecast lands as a dashed accent segment on the final frame. -->
+    <svg data-testid="sparkline" :viewBox="`0 0 ${SPARK.W} ${SPARK.H}`" width="100%">
+      <line
+        :x1="SPARK.padL" :y1="SPARK.H - SPARK.padB" :x2="SPARK.W - SPARK.padR"
+        :y2="SPARK.H - SPARK.padB" stroke="#cbd5e1" stroke-width="1"
+      />
+      <line
+        :x1="SPARK.padL" :y1="SPARK.padT" :x2="SPARK.padL" :y2="SPARK.H - SPARK.padB"
+        stroke="#cbd5e1" stroke-width="1"
+      />
+      <text
+        v-for="(f, k) in dfgData.frames" :key="k"
+        :x="SPARK.X(k)" :y="SPARK.H - 6" text-anchor="middle" font-size="8" fill="#94a3b8"
+      >t{{ k + 1 }}</text>
+      <polyline
+        data-testid="spark-line" fill="none" stroke="#0f172a" stroke-width="2"
+        stroke-linejoin="round" stroke-linecap="round" :points="spark.obsPoints"
+      />
+      <polyline
+        v-if="spark.forecastPoints" data-testid="spark-forecast" fill="none"
+        :stroke="dfgData.accent" stroke-width="2" stroke-dasharray="4 3"
+        stroke-linecap="round" :points="spark.forecastPoints"
+      />
       <circle
-        v-for="n in state.sparkPoints"
-        :key="n"
-        data-testid="spark-point"
+        v-for="(d, k) in spark.dots" :key="k" data-testid="spark-point"
+        :cx="d.cx" :cy="d.cy" :r="d.isF ? 3.2 : 3"
+        :fill="d.isF ? dfgData.accent : '#0f172a'"
       />
+      <text
+        :x="spark.valLabel.x" :y="spark.valLabel.y" :text-anchor="spark.valLabel.anchor"
+        font-size="9" font-weight="700" :fill="spark.valLabel.fill"
+      >{{ spark.valLabel.text }}</text>
     </svg>
-    <!-- Step ④ ("Forecast next week → forecasted DFG") lands only on the forecast frame. -->
-    <div v-if="state.step4Visible" data-testid="step-4">
-      ④ Forecast next week → forecasted DFG
+        </div>
+        <div data-testid="step-3" class="cap">{{ STEPS[2] }}</div>
+      </div>
+    </div>
+
+    <!-- ④ forecast caption — lands only on the forecast frame, beneath the woven row. -->
+    <div v-if="state.step4Visible" data-testid="step-4" class="cap cap-forecast">
+      {{ STEPS[3] }}
     </div>
   </div>
 </template>
+
+<style scoped>
+/* Woven full-width layout, ported from prototypes/dfg-anim/layout.html (woven branch).
+   Monochrome + the single KU Leuven accent (dfgData.accent #1d4ed8); no 3D, no shadows. */
+.dfg-evolution {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  color: #0f172a;
+  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+.woven-grid {
+  display: grid;
+  grid-template-columns: 0.85fr 24px 1.5fr 24px 1.2fr;
+  align-items: stretch;
+  flex: 1;
+  min-height: 0;
+  gap: 4px;
+}
+.wcol {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  justify-content: center;
+  gap: 6px;
+}
+.warrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 22px;
+  color: #94a3b8;
+}
+.slot {
+  flex: 1;
+  min-height: 0;
+}
+.wcol-log .slot {
+  max-height: 160px;
+}
+.slot-spark {
+  flex: none;
+  height: 104px;
+}
+.cap {
+  font-size: 12px;
+  color: #475569;
+  text-align: center;
+  line-height: 1.35;
+}
+.spark-title {
+  font-size: 11px;
+  color: #64748b;
+  text-align: center;
+}
+.cap-forecast {
+  margin-top: 8px;
+  font-weight: 600;
+  font-size: 12.5px;
+}
+</style>

--- a/slides/template/components/dfgFrameState.js
+++ b/slides/template/components/dfgFrameState.js
@@ -7,18 +7,48 @@
 export const strokeWidthFor = (weight, maxFreq) =>
   Number((0.7 + 2.9 * Math.sqrt(weight / maxFreq)).toFixed(2))
 
+const INK = '#0f172a'
+const NEUTRAL = '#475569'
+
 export function frameState(data, i) {
   const frame = data.frames[i]
   const isForecast = frame.kind === 'forecast'
   const edges = {}
   for (const edge of data.edges) {
+    // On the forecast frame every edge re-colours to the single accent, draws with the
+    // accent arrowhead, and goes dashed; otherwise the hero edge reads in ink and the
+    // chain edges in neutral grey (per render_svg.js applyFrame).
     edges[edge.id] = {
       strokeWidth: strokeWidthFor(frame.weights[edge.id], data.max_freq),
       isForecast,
+      stroke: isForecast ? data.accent : edge.hero ? INK : NEUTRAL,
+      marker: isForecast ? 'arrowA' : 'arrow',
+      dashed: isForecast,
     }
   }
+  // Hero-edge weight readout: the raw weekly frequency while observed; on the forecast
+  // frame, the prediction (≈) alongside the held-out truth (per render_svg.js heroLabel).
+  const heroWeight = frame.weights[data.hero]
+  const heroLabel = {
+    text: isForecast
+      ? `≈${heroWeight} (truth ${frame.truth ? frame.truth[data.hero] : '?'})`
+      : `${heroWeight}`,
+    fill: isForecast ? data.accent : NEUTRAL,
+  }
+
+  // On the forecast frame, a faint ghost of the held-out truth is drawn over the hero edge
+  // so the prediction can be read against ground truth (per render_svg.js ghost).
+  const heroGhost = {
+    visible: isForecast && Boolean(frame.truth),
+    strokeWidth: isForecast && frame.truth
+      ? strokeWidthFor(frame.truth[data.hero], data.max_freq)
+      : 0,
+  }
+
   return {
     edges,
+    heroLabel,
+    heroGhost,
     sparkPoints: i + 1,
     sliceIndex: i,
     step4Visible: isForecast,

--- a/slides/template/components/dfgGeometry.js
+++ b/slides/template/components/dfgGeometry.js
@@ -1,0 +1,43 @@
+// Pure geometry/scale helpers for the slide-3 DFG-evolution figure. No DOM, no Vue —
+// extracted from the prototype renderers (render_svg.js + render_diagram.js) so the layout
+// math is unit-testable in isolation and the component stays a thin shell over it.
+
+// Trim a segment so it starts/ends a gap away from the node centres (render_svg.js trim()),
+// leaving room for the node boxes and the arrowhead.
+export function trim(x1, y1, x2, y2, gapStart, gapEnd) {
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const L = Math.hypot(dx, dy) || 1
+  return [
+    x1 + (dx / L) * gapStart, y1 + (dy / L) * gapStart,
+    x2 - (dx / L) * gapEnd, y2 - (dy / L) * gapEnd,
+  ]
+}
+
+// Frame-independent trimmed geometry [x1, y1, x2, y2] for every edge, keyed by edge id.
+export function edgeGeometry(nodes, edges, gapStart = 4.4, gapEnd = 4.8) {
+  const byId = Object.fromEntries(nodes.map((n) => [n.id, n]))
+  return Object.fromEntries(
+    edges.map((e) => {
+      const s = byId[e.source]
+      const t = byId[e.target]
+      return [e.id, trim(s.x, s.y, t.x, t.y, gapStart, gapEnd)]
+    }),
+  )
+}
+
+// Sparkline coordinate scales (render_diagram.js buildSpark). The data-centred y-range shows
+// the gentle weekly wiggle without zooming so hard it reads as a dramatic drift (that story
+// is reserved for slide 4). Returns the X(k) and Y(v) mapping functions.
+export function sparkScale(vals, { W, H, padL, padR, padT, padB }) {
+  const vmin = Math.min(...vals)
+  const vmax = Math.max(...vals)
+  const span = vmax - vmin || 1
+  const yLo = vmin - span * 0.9 - 4
+  const yHi = vmax + span * 0.6 + 4
+  const n = vals.length
+  return {
+    X: (k) => padL + (k * (W - padL - padR)) / (n - 1),
+    Y: (v) => H - padB - ((v - yLo) / (yHi - yLo)) * (H - padT - padB),
+  }
+}

--- a/slides/template/components/dfgGeometry.test.js
+++ b/slides/template/components/dfgGeometry.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { trim, edgeGeometry, sparkScale } from './dfgGeometry.js'
+import { dfgData } from './dfgData.js'
+
+describe('dfgGeometry — pure layout helpers', () => {
+  it('trims a segment by the given gaps at each end, preserving direction', () => {
+    // horizontal segment of length 10, trim 2 off the start and 3 off the end → [2, 0, 7, 0]
+    expect(trim(0, 0, 10, 0, 2, 3)).toEqual([2, 0, 7, 0])
+  })
+
+  it('handles a zero-length segment without dividing by zero', () => {
+    expect(trim(5, 5, 5, 5, 1, 1).every(Number.isFinite)).toBe(true)
+  })
+
+  it('produces trimmed geometry for every edge, keyed by id', () => {
+    const geo = edgeGeometry(dfgData.nodes, dfgData.edges)
+    expect(Object.keys(geo)).toHaveLength(dfgData.edges.length)
+    // each entry is a finite [x1, y1, x2, y2] tuple
+    for (const id of Object.keys(geo)) {
+      expect(geo[id]).toHaveLength(4)
+      expect(geo[id].every(Number.isFinite)).toBe(true)
+    }
+  })
+
+  it('maps frame index to x left-to-right and higher weight to a smaller y (up)', () => {
+    const vals = [346, 314, 316, 316]
+    const dims = { W: 200, H: 96, padL: 26, padR: 12, padT: 12, padB: 20 }
+    const { X, Y } = sparkScale(vals, dims)
+    expect(X(0)).toBeLessThan(X(3)) // weeks advance rightward
+    expect(Y(346)).toBeLessThan(Y(314)) // the larger value sits higher on screen
+  })
+})


### PR DESCRIPTION
## What

Implements **#62** — folds the approved prototype renderers (`render_svg.js` + `render_diagram.js`, woven layout only) into a complete, on-brand `DfgEvolution.vue`. Any frame now renders the full woven figure that narrates the PMF workflow and lands the capability to forecast next week's DFG.

Built test-first on top of #61's scaffold (`vitest` + `@vue/test-utils`), keeping the declarative design (pure `frameState` core + reactive template), so the 6 original tests stay green.

## Figure parts (per frame, driven by the master `frame` index)

- **Morphing DFG** — sqrt-scaled edge stroke widths; the forecast frame recolours every edge to the accent `#1d4ed8`, switches to the accent arrowhead, and goes dashed; hero edge reads in ink off-forecast; hero weight label (`346 → 314 → 316 → ≈316 (truth 315)`); held-out-truth ghost over the hero edge on the forecast frame.
- **Accumulating sparkline** — observed polyline grows one point per frame; the held-out forecast lands as a dashed accent segment on the final frame only.
- **Sliding event-log slice band** — a dashed band slides right one week per frame to grab a later time-slice.
- **Lockstep captions ①②③④** — ④ ("Forecast next week → forecasted DFG") reveals only on the forecast frame. Wording uses "weekly sublog" — no reserved term "window".

## Tests (TDD)

`pnpm test` → **17 passed** (13 component choreography + 4 pure-geometry; 6 original #61 tests still green). Geometry/scale math extracted into a unit-tested `dfgGeometry.js`.

## Scope

Render-only. Slide integration + `v-click` + the "window" reword is **#63**; prototype dir / `dfg.gif` / `dfg.mp4` / `cytoscape` cleanup is **#64**.

## Acceptance criteria

- [x] Edge stroke-widths scale to weight; forecast frame recolours to accent, earlier frames don't
- [x] Sparkline accumulates one point/frame, forecast point/segment dashed in accent only on the final frame
- [x] Event-log slice band slides right one week per frame
- [x] Step-labels ①–④ lockstep; ④ reveals only on the forecast frame
- [x] Monochrome + single accent only, no 3D/shadows, crisp vector SVG
- [x] No new runtime dependencies
- [x] #61's tests still pass

Closes #62