### PR TITLE
feat(demo): Diff view — dfg_diff + diff_svg + Side-by-side/Diff toggle (S3)

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -1,8 +1,10 @@
 """Gradio app — the bundled forecast explorer (demo slice 1).
 
-Thin glue over the deep modules ``forecast.forecast_bundled`` and
-``render.dfg_json_to_svg``: a dataset/model picker drives twin panes (forecast
-DFG | actual-future DFG) with an ER/MAE/RMSE metrics strip below. The bundled
+Thin glue over the deep modules ``forecast.forecast_bundled``,
+``render.dfg_json_to_svg`` / ``render.diff_svg`` and ``dfg_diff``: a
+dataset/model picker drives twin panes (forecast DFG | actual-future DFG), with
+a ``[Side-by-side | Diff]`` toggle that swaps them for one colour-coded diff
+overlay. An ER/MAE/RMSE metrics strip stays below in both views. The bundled
 path is a holdout backtest (ADR-0004), so the metrics are genuine accuracy.
 
 Served entirely from precomputed assets — GPU-free. Launch plainly; ``mcp_server``
@@ -17,25 +19,25 @@ from typing import Any
 
 import gradio as gr
 from forecast import forecast_bundled
-from render import dfg_json_to_svg
+from render import dfg_json_to_svg, diff_svg
 
 # Slice-1 scope: only the precomputed bundled pairs are offered as choices.
 DATASETS: list[str] = ["bpi2017"]
 MODELS: list[str] = ["chronos2"]
 
 
+def _scrollable(svg: str) -> str:
+    """Wrap a rendered SVG so it scrolls within its pane."""
+    return f'<div style="overflow:auto; max-height:70vh">{svg}</div>'
+
+
 def _pane(dfg: dict[str, Any]) -> str:
-    """Wrap a rendered DFG SVG so it scrolls within its pane."""
-    return f'<div style="overflow:auto; max-height:70vh">{dfg_json_to_svg(dfg)}</div>'
+    """Render a DFG to a scrollable SVG pane."""
+    return _scrollable(dfg_json_to_svg(dfg))
 
 
-def load(dataset: str, model: str) -> tuple[str, str, str, str, str]:
-    """Resolve one bundled forecast into the five UI outputs.
-
-    Returns:
-        ``(forecast_pane_html, actual_pane_html, er, mae, rmse)``.
-    """
-    result = forecast_bundled(dataset, model)
+def _render_panes(result: dict[str, Any]) -> tuple[str, str, str, str, str]:
+    """Render the side-by-side outputs from a resolved forecast triple."""
     metrics = result["metrics"]
     return (
         _pane(result["forecast_dfg"]),
@@ -44,6 +46,31 @@ def load(dataset: str, model: str) -> tuple[str, str, str, str, str]:
         f"{metrics['mae']:.3f}",
         f"{metrics['rmse']:.3f}",
     )
+
+
+def _render_diff(result: dict[str, Any]) -> str:
+    """Render the colour-coded diff overlay pane from a resolved forecast triple."""
+    return _scrollable(diff_svg(result["forecast_dfg"], result["actual_dfg"]))
+
+
+def load(dataset: str, model: str) -> tuple[str, str, str, str, str]:
+    """Resolve one bundled forecast into the five side-by-side UI outputs.
+
+    Returns:
+        ``(forecast_pane_html, actual_pane_html, er, mae, rmse)``.
+    """
+    return _render_panes(forecast_bundled(dataset, model))
+
+
+def load_diff(dataset: str, model: str) -> str:
+    """Resolve one bundled forecast into the colour-coded diff overlay pane.
+
+    Returns:
+        The diff overlay SVG wrapped in a scrollable pane (grey = matched,
+        amber dashed = it happened but the forecast missed it, red dashed = the
+        forecast predicted it but it did not happen).
+    """
+    return _render_diff(forecast_bundled(dataset, model))
 
 
 def build() -> gr.Blocks:
@@ -58,9 +85,16 @@ def build() -> gr.Blocks:
         with gr.Row():
             dataset = gr.Dropdown(DATASETS, value=DATASETS[0], label="Dataset")
             model = gr.Dropdown(MODELS, value=MODELS[0], label="Model")
-        with gr.Row():
+        view = gr.Radio(
+            ["Side-by-side", "Diff"],
+            value="Side-by-side",
+            label="View",
+        )
+        with gr.Row(visible=True) as twin_panes:
             forecast_pane = gr.HTML(label="Forecast DFG")
             actual_pane = gr.HTML(label="Actual-future DFG")
+        with gr.Row(visible=False) as diff_overlay:
+            diff_pane = gr.HTML(label="Diff (forecast vs actual)")
         with gr.Row():
             er = gr.Textbox(label="ER", interactive=False)
             mae = gr.Textbox(label="MAE", interactive=False)
@@ -68,9 +102,27 @@ def build() -> gr.Blocks:
 
         outputs = [forecast_pane, actual_pane, er, mae, rmse]
         inputs = [dataset, model]
+
+        def refresh(dataset: str, model: str) -> tuple[Any, ...]:
+            """Recompute every pane so both views stay in sync with the pickers.
+
+            Resolves the forecast once and fans it into both views, so the diff
+            overlay and the side-by-side panes always show the same triple.
+            """
+            result = forecast_bundled(dataset, model)
+            return (*_render_panes(result), _render_diff(result))
+
+        all_outputs = [*outputs, diff_pane]
         for picker in inputs:
-            picker.change(load, inputs, outputs)
-        demo.load(load, inputs, outputs)
+            picker.change(refresh, inputs, all_outputs)
+        demo.load(refresh, inputs, all_outputs)
+
+        def set_view(view: str) -> tuple[Any, Any]:
+            """Swap the twin panes for the diff overlay; metrics strip stays put."""
+            is_diff = view == "Diff"
+            return gr.update(visible=not is_diff), gr.update(visible=is_diff)
+
+        view.change(set_view, view, [twin_panes, diff_overlay])
     return demo
 
 

--- a/demo/dfg_diff.py
+++ b/demo/dfg_diff.py
@@ -1,0 +1,53 @@
+"""Classify how a forecast DFG drifted from the actual-future DFG.
+
+``dfg_diff`` is a pure deep module: it takes two DFG JSON documents (the
+``{"nodes": [...], "arcs": [...]}`` shape from ``pmf_tsfm.er.dfg.dfg_to_json``)
+and partitions their directly-follows (DF) relations into three classes.
+
+Relations are keyed on the ``(from_label, to_label)`` activity pair — *not* on
+node ids, which number independently in the two DFGs. Semantics follow a
+conventional ``diff(from=forecast, to=actual)``:
+
+    matched  relation present in both forecast and actual
+    added    present in actual but not forecast  (it happened, the forecast missed it)
+    removed  present in forecast but not actual   (the forecast predicted it, it did not happen)
+
+These map to the Diff view's colour coding (grey / amber dashed / red dashed)
+and are reused by the upload drift descriptors in a later slice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _relations(dfg: dict[str, Any]) -> dict[tuple[str, str], int]:
+    """Map each DF relation ``(from_label, to_label)`` to its arc weight."""
+    label = {node["id"]: node["label"] for node in dfg["nodes"]}
+    return {(label[arc["from"]], label[arc["to"]]): arc["freq"] for arc in dfg["arcs"]}
+
+
+def dfg_diff(
+    forecast_dfg: dict[str, Any], actual_dfg: dict[str, Any]
+) -> dict[str, list[dict[str, Any]]]:
+    """Partition DF relations of two DFGs into matched / added / removed.
+
+    Args:
+        forecast_dfg: The forecast DFG (``{"nodes": [...], "arcs": [...]}``).
+        actual_dfg:   The actual-future DFG, same shape.
+
+    Returns:
+        ``{"matched": [...], "added": [...], "removed": [...]}`` where each entry
+        is ``{"from": label, "to": label, "freq": int}``. ``matched``/``added``
+        carry the actual weight; ``removed`` carries the forecast weight.
+    """
+    forecast = _relations(forecast_dfg)
+    actual = _relations(actual_dfg)
+
+    def entry(rel: tuple[str, str], freq: int) -> dict[str, Any]:
+        return {"from": rel[0], "to": rel[1], "freq": freq}
+
+    matched = [entry(rel, actual[rel]) for rel in actual if rel in forecast]
+    added = [entry(rel, actual[rel]) for rel in actual if rel not in forecast]
+    removed = [entry(rel, forecast[rel]) for rel in forecast if rel not in actual]
+    return {"matched": matched, "added": added, "removed": removed}

--- a/demo/render.py
+++ b/demo/render.py
@@ -17,6 +17,13 @@ from __future__ import annotations
 from typing import Any
 
 import graphviz
+from dfg_diff import dfg_diff
+
+# Diff colour coding (PRD #65): grey = matched, amber dashed = it happened but the
+# forecast missed it, red dashed = the forecast predicted it but it did not happen.
+_MATCHED_COLOUR = "#9e9e9e"
+_ADDED_COLOUR = "#ffb300"
+_REMOVED_COLOUR = "#e53935"
 
 
 def dfg_json_to_svg(dfg: dict[str, Any]) -> str:
@@ -33,4 +40,44 @@ def dfg_json_to_svg(dfg: dict[str, Any]) -> str:
         graph.node(str(node["id"]), label=node["label"])
     for arc in dfg["arcs"]:
         graph.edge(str(arc["from"]), str(arc["to"]), label=str(arc["freq"]))
+    return graph.pipe(format="svg").decode("utf-8")
+
+
+def diff_svg(forecast_dfg: dict[str, Any], actual_dfg: dict[str, Any]) -> str:
+    """Render the forecast/actual diff as one colour-coded overlay SVG.
+
+    Arcs are partitioned by :func:`dfg_diff.dfg_diff` and drawn as:
+
+    * **matched** — solid grey,
+    * **added** (it happened, the forecast missed it) — amber dashed,
+    * **removed** (the forecast predicted it, it did not happen) — red dashed.
+
+    Args:
+        forecast_dfg: The forecast DFG (``{"nodes": [...], "arcs": [...]}``).
+        actual_dfg:   The actual-future DFG, same shape.
+
+    Returns:
+        An ``<svg>`` document as a string.
+    """
+    diff = dfg_diff(forecast_dfg, actual_dfg)
+    graph = graphviz.Digraph()
+
+    # Nodes are the union of every relation's endpoints, keyed (and id'd) by label.
+    labels = {
+        end
+        for entries in diff.values()
+        for entry in entries
+        for end in (entry["from"], entry["to"])
+    }
+    for label in labels:
+        graph.node(label, label=label)
+
+    styling = {
+        "matched": {"color": _MATCHED_COLOUR},
+        "added": {"color": _ADDED_COLOUR, "style": "dashed"},
+        "removed": {"color": _REMOVED_COLOUR, "style": "dashed"},
+    }
+    for diff_class, entries in diff.items():
+        for entry in entries:
+            graph.edge(entry["from"], entry["to"], label=str(entry["freq"]), **styling[diff_class])
     return graph.pipe(format="svg").decode("utf-8")

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -1,13 +1,16 @@
-"""Tests for the bundled forecast explorer demo (slice 1).
+"""Tests for the bundled forecast explorer demo.
 
-Two deep modules are tested here through their public interfaces:
+The deep modules are tested through their public interfaces:
 
 render.py
-  - test_dfg_json_to_svg_returns_svg          valid <svg> string
-  - (further behaviours added per TDD cycle)
+  - dfg_json_to_svg — a DFG JSON renders to a valid <svg> string
+  - diff_svg        — a forecast/actual pair renders to a colour-coded overlay
+
+dfg_diff.py
+  - dfg_diff        — DF relations partition into matched / added / removed
 
 forecast.py
-  - (added per TDD cycle)
+  - forecast_bundled — reads the committed assets into the forecast triple
 
 The Gradio glue (app.py) and the precompute script are smoke-tested only.
 """
@@ -15,13 +18,15 @@ The Gradio glue (app.py) and the precompute script are smoke-tested only.
 from __future__ import annotations
 
 import json
+import re
 
 import forecast
 import numpy as np
 import pytest
+from dfg_diff import dfg_diff
 from forecast import forecast_bundled
 from precompute_demo import frequencies_to_dfg_json, precompute_one
-from render import dfg_json_to_svg
+from render import dfg_json_to_svg, diff_svg
 
 # ---------------------------------------------------------------------------
 # Shared DFG fixture — a tiny ▶ → A → B → ■ graph
@@ -73,6 +78,137 @@ def test_dfg_json_to_svg_shows_arc_weights():
     svg = dfg_json_to_svg(SMALL_DFG)
     # The A -> B arc has the distinctive weight 4.
     assert ">4<" in svg
+
+
+# ---------------------------------------------------------------------------
+# dfg_diff.dfg_diff
+#
+# Classifies DF relations (keyed on (from_label, to_label)) between a forecast
+# DFG and the actual-future DFG, with conventional diff(from=forecast, to=actual)
+# semantics:
+#   matched = in both                          (grey)
+#   added   = in actual, not forecast          (amber dashed: happened, missed)
+#   removed = in forecast, not actual          (red dashed: predicted, didn't happen)
+# ---------------------------------------------------------------------------
+
+
+def _rels(entries):
+    """The set of (from, to) relation keys in a diff class."""
+    return {(e["from"], e["to"]) for e in entries}
+
+
+def test_dfg_diff_identical_all_matched():
+    """Diffing a DFG against itself classifies every relation as matched."""
+    diff = dfg_diff(SMALL_DFG, SMALL_DFG)
+    assert _rels(diff["matched"]) == {("▶", "A"), ("A", "B"), ("B", "■")}
+    assert diff["added"] == [] and diff["removed"] == []
+
+
+def test_dfg_diff_disjoint_all_added_and_removed():
+    """No shared relations → forecast's are all removed, actual's all added."""
+    forecast = {
+        "nodes": [{"label": "▶", "id": 0}, {"label": "X", "id": 1}],
+        "arcs": [{"from": 0, "to": 1, "freq": 2}],  # ▶ -> X
+    }
+    actual = {
+        "nodes": [{"label": "▶", "id": 9}, {"label": "Y", "id": 8}],
+        "arcs": [{"from": 9, "to": 8, "freq": 3}],  # ▶ -> Y
+    }
+    diff = dfg_diff(forecast, actual)
+    assert diff["matched"] == []
+    assert _rels(diff["removed"]) == {("▶", "X")}
+    assert _rels(diff["added"]) == {("▶", "Y")}
+
+
+def test_dfg_diff_partial_overlap_is_label_keyed_with_directional_freq():
+    """Relations key on labels (not ids); freq comes from the right DFG."""
+    forecast = {
+        "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "C", "id": 2}],
+        "arcs": [
+            {"from": 0, "to": 1, "freq": 4},  # A -> B   (shared)
+            {"from": 1, "to": 2, "freq": 7},  # B -> C   (forecast only -> removed)
+        ],
+    }
+    actual = {
+        # Same labels, deliberately different ids, to prove label-keying.
+        "nodes": [{"label": "A", "id": 5}, {"label": "B", "id": 6}, {"label": "D", "id": 7}],
+        "arcs": [
+            {"from": 5, "to": 6, "freq": 9},  # A -> B   (shared, different weight)
+            {"from": 6, "to": 7, "freq": 2},  # B -> D   (actual only -> added)
+        ],
+    }
+    diff = dfg_diff(forecast, actual)
+
+    assert _rels(diff["matched"]) == {("A", "B")}
+    assert _rels(diff["added"]) == {("B", "D")}
+    assert _rels(diff["removed"]) == {("B", "C")}
+    # matched/added carry the actual weight; removed carries the forecast weight.
+    assert diff["matched"][0]["freq"] == 9
+    assert diff["added"][0]["freq"] == 2
+    assert diff["removed"][0]["freq"] == 7
+
+
+def test_dfg_diff_handles_start_end_marker_relations():
+    """Relations touching the ▶/■ markers classify like any other relation."""
+    # forecast: ▶ -> A -> ■ ; actual: ▶ -> A (drops the A -> ■ ending).
+    forecast = {
+        "nodes": [{"label": "▶", "id": 0}, {"label": "A", "id": 1}, {"label": "■", "id": 2}],
+        "arcs": [{"from": 0, "to": 1, "freq": 5}, {"from": 1, "to": 2, "freq": 5}],
+    }
+    actual = {
+        "nodes": [{"label": "▶", "id": 0}, {"label": "A", "id": 1}],
+        "arcs": [{"from": 0, "to": 1, "freq": 6}],
+    }
+    diff = dfg_diff(forecast, actual)
+    assert _rels(diff["matched"]) == {("▶", "A")}
+    assert _rels(diff["removed"]) == {("A", "■")}  # forecast predicted an ending that didn't happen
+    assert diff["added"] == []
+
+
+def test_dfg_diff_empty_inputs_yield_empty_partition():
+    """Empty DFGs diff to an empty (but well-formed) partition — no crash."""
+    empty = {"nodes": [], "arcs": []}
+    diff = dfg_diff(empty, empty)
+    assert diff == {"matched": [], "added": [], "removed": []}
+
+
+# ---------------------------------------------------------------------------
+# render.diff_svg
+# ---------------------------------------------------------------------------
+
+
+def test_diff_svg_returns_svg():
+    """A pair of DFGs renders to a single overlay SVG document string."""
+    svg = diff_svg(SMALL_DFG, ACTUAL_DFG)
+    assert isinstance(svg, str)
+    assert "<svg" in svg
+
+
+def test_diff_svg_colour_codes_the_three_diff_classes():
+    """A drifting pair emits matched (grey solid), added (amber dashed),
+    removed (red dashed) arcs — one of each."""
+    # A -> B matched; B -> D added (actual only); B -> C removed (forecast only).
+    forecast = {
+        "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "C", "id": 2}],
+        "arcs": [{"from": 0, "to": 1, "freq": 4}, {"from": 1, "to": 2, "freq": 7}],
+    }
+    actual = {
+        "nodes": [{"label": "A", "id": 5}, {"label": "B", "id": 6}, {"label": "D", "id": 7}],
+        "arcs": [{"from": 5, "to": 6, "freq": 9}, {"from": 6, "to": 7, "freq": 2}],
+    }
+    svg = diff_svg(forecast, actual)
+
+    # All three diff classes are present, by colour.
+    grey, amber, red = "#9e9e9e", "#ffb300", "#e53935"
+    assert grey in svg and amber in svg and red in svg
+
+    # Added/removed are dashed; matched is solid. Inspect each coloured edge path.
+    def stroke_paths(colour):
+        return re.findall(rf'stroke="{colour}"[^/]*?d="', svg)
+
+    assert all("stroke-dasharray" in p for p in stroke_paths(amber))  # added dashed
+    assert all("stroke-dasharray" in p for p in stroke_paths(red))  # removed dashed
+    assert all("stroke-dasharray" not in p for p in stroke_paths(grey))  # matched solid
 
 
 # ---------------------------------------------------------------------------
@@ -214,3 +350,35 @@ def test_app_builds_blocks(asset_dir):
     import app
 
     assert isinstance(app.build(), gr.Blocks)
+
+
+@pytest.fixture
+def drift_asset_dir(tmp_path, monkeypatch):
+    """Assets whose forecast and actual genuinely drift (matched + added + removed)."""
+    # forecast: A -> B, B -> C ; actual: A -> B, B -> D  → matched A->B, removed B->C, added B->D.
+    forecast_dfg = {
+        "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "C", "id": 2}],
+        "arcs": [{"from": 0, "to": 1, "freq": 4}, {"from": 1, "to": 2, "freq": 7}],
+    }
+    actual_dfg = {
+        "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "D", "id": 2}],
+        "arcs": [{"from": 0, "to": 1, "freq": 9}, {"from": 1, "to": 2, "freq": 2}],
+    }
+    base = tmp_path / "bpi2017" / "chronos2"
+    base.mkdir(parents=True)
+    (base / "forecast_dfg.json").write_text(json.dumps(forecast_dfg))
+    (base / "actual_dfg.json").write_text(json.dumps(actual_dfg))
+    (base / "metrics.json").write_text(json.dumps(METRICS))
+    monkeypatch.setattr(forecast, "ASSETS_ROOT", tmp_path)
+    return tmp_path
+
+
+def test_app_load_diff_produces_colour_coded_overlay(drift_asset_dir):
+    """app.load_diff renders the forecast/actual pair into one diff overlay pane."""
+    pytest.importorskip("gradio")
+    import app
+
+    diff_html = app.load_diff("bpi2017", "chronos2")
+    assert "<svg" in diff_html
+    # The overlay carries the diff colour coding (grey / amber / red).
+    assert "#9e9e9e" in diff_html and "#ffb300" in diff_html and "#e53935" in diff_html


### PR DESCRIPTION
Closes #68

## What this adds

Slice-1 **Diff view** for spotting where the forecast drifted from reality.

- **`demo/dfg_diff.py`** — new pure deep module. `dfg_diff(forecast_dfg, actual_dfg)` partitions DF relations into `{matched, added, removed}`, keyed on `(from_label, to_label)` so the two DFGs' independent id spaces don't matter. Built for reuse by the slice-2 upload drift descriptors.
- **`render.diff_svg`** — renders the colour-coded overlay: **grey = matched · amber dashed = it happened but the forecast missed it · red dashed = the forecast predicted it but it did not happen**.
- **`demo/app.py`** — a `[Side-by-side | Diff]` toggle swaps the twin panes for the single overlay; the ER/MAE/RMSE metrics strip stays in both views. The event handler resolves the forecast once and fans it into both views.

## Acceptance criteria (all met)

- [x] `dfg_diff` returns an `{added, removed, matched}` partition of DF relations
- [x] `diff_svg` renders the three diff classes with the specified colour/line coding
- [x] `[Side-by-side | Diff]` toggle switches views; metrics strip stays in both modes
- [x] Unit tests: `dfg_diff` (identical / disjoint / partial overlap / label-keyed / ▶/■ / empty)
- [x] Unit test: `diff_svg` emits the three colour-coded classes for drifting DFGs
- [x] ruff + pytest green

## Verification

20/20 demo tests pass; full repo suite 285 pass; ruff clean. Verified the live Gradio app: toggling Side-by-side ↔ Diff swaps panes correctly, metrics persist, and the overlay colour-codes drift against the real `bpi2017/chronos2` assets.

## Follow-up (not in this PR)

Diff-view *interpretability* — per-arc `forecast → actual` weight labels, emphasis on changed arcs, and an embedded colour legend — is tracked separately (out of #68's scope per PRD #65).