### PR TITLE
feat(slides): integrate DfgEvolution into slide 3 with v-click

### DIFF
--- a/slides/talk_design/outline.md
+++ b/slides/talk_design/outline.md
@@ -49,6 +49,10 @@ For brief / hard constraints / spoken lines, see `../SLIDES.md`.
 - One sentence: *"Each DF edge becomes a univariate time series — like website
   traffic per day, but for one activity transition in your process."*
 - Calibration: *"We aggregate daily, forecast 7 days ahead."*
+- **Layout note:** rendered as one **full-width woven figure** (`DfgEvolution.vue`) — the
+  workflow diagram and DFG-evolution animation are a single unified picture advanced by
+  `v-click` (frames t₁→t₄, climaxing on the forecast frame). Departs from the original
+  two-column split; pre-authorised by PRD #60 / issue #63.
 
 ## Beat 3 — Where current PMF stands (75s)
 **Purpose:** Anchor the gap that motivates TSFMs.

--- a/slides/template/components/DfgEvolution.test.js
+++ b/slides/template/components/DfgEvolution.test.js
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import DfgEvolution from './DfgEvolution.vue'
 
-// Stroke width for an edge weight, per the approved prototype:
-// scaleW(f) = 0.7 + 2.9 * sqrt(f / max_freq), max_freq = 927.
-const expectedWidth = (f) => 0.7 + 2.9 * Math.sqrt(f / 927)
+// Stroke width for an edge weight:
+// scaleW(f) = 0.5 + 1.6 * sqrt(f / max_freq), max_freq = 927.
+const expectedWidth = (f) => 0.5 + 1.6 * Math.sqrt(f / 927)
 
 const heroWidth = (wrapper) =>
   Number(wrapper.get('[data-edge="sent__cancelled"]').attributes('stroke-width'))

--- a/slides/template/components/DfgEvolution.vue
+++ b/slides/template/components/DfgEvolution.vue
@@ -54,7 +54,7 @@ const weekLabel = computed(() =>
 // Hero-edge sparkline geometry (per render_diagram.js buildSpark). Frame-independent scales;
 // the data-centred y-range shows the gentle weekly wiggle without faking a dramatic drift.
 const SPARK = (() => {
-  const dims = { W: 200, H: 96, padL: 26, padR: 12, padT: 12, padB: 20 }
+  const dims = { W: 200, H: 140, padL: 26, padR: 12, padT: 16, padB: 24 }
   const vals = dfgData.frames.map((f) => f.weights[dfgData.hero])
   const { X, Y } = sparkScale(vals, dims)
   return { ...dims, vals, X, Y, n: dfgData.frames.length }
@@ -97,7 +97,7 @@ const spark = computed(() => {
       data-testid="log-slice" :data-slice-index="state.sliceIndex"
       :viewBox="`0 0 ${LOG.W} ${LOG.H}`" width="100%" height="100%"
     >
-      <text :x="LOG.x0" y="10" font-size="9" fill="#64748b" font-weight="600">event log</text>
+      <text :x="LOG.x0" y="10" style="font-size: 9px" fill="#64748b" font-weight="600">event log</text>
       <rect
         v-for="(cell, k) in LOG.cells" :key="k"
         :x="cell.x" :y="cell.y" :width="LOG.bw" :height="LOG.bh" rx="1.5" fill="#e2e8f0"
@@ -110,7 +110,7 @@ const spark = computed(() => {
         />
         <text
           :x="LOG.x0 - 2 + LOG.bandW / 2" :y="LOG.labelY" text-anchor="middle"
-          font-size="9" font-weight="700" :fill="dfgData.accent"
+          style="font-size: 9px" font-weight="700" :fill="dfgData.accent"
         >{{ weekLabel }}</text>
       </g>
     </svg>
@@ -128,7 +128,7 @@ const spark = computed(() => {
         <marker
           v-for="m in [{ id: 'arrow', col: '#475569' }, { id: 'arrowA', col: dfgData.accent }]"
           :key="m.id" :id="m.id" viewBox="0 0 10 10" refX="8" refY="5"
-          markerWidth="3.4" markerHeight="3.4" orient="auto-start-reverse"
+          markerWidth="2.8" markerHeight="2.8" orient="auto-start-reverse"
           markerUnits="userSpaceOnUse"
         >
           <path d="M0,0 L10,5 L0,10 z" :fill="m.col" />
@@ -161,7 +161,7 @@ const spark = computed(() => {
         data-testid="hero-label"
         :x="(edgeGeo[dfgData.hero][0] + edgeGeo[dfgData.hero][2]) / 2 + 6"
         :y="(edgeGeo[dfgData.hero][1] + edgeGeo[dfgData.hero][3]) / 2 - 1"
-        font-size="3.4" font-weight="700" :fill="state.heroLabel.fill"
+        style="font-size: 3.4px" font-weight="700" :fill="state.heroLabel.fill"
       >{{ state.heroLabel.text }}</text>
       <!-- Nodes drawn above edges. Activity = labelled rect; start ● / end ■. -->
       <g v-for="node in dfgData.nodes" :key="node.id" :data-node="node.id">
@@ -172,7 +172,7 @@ const spark = computed(() => {
           />
           <text
             :x="node.x" :y="node.y + 1.3" text-anchor="middle"
-            font-size="3.4" fill="#0f172a"
+            style="font-size: 3.4px" fill="#0f172a"
           >{{ node.label }}</text>
         </template>
         <circle
@@ -197,7 +197,10 @@ const spark = computed(() => {
         <div class="slot slot-spark">
     <!-- Accumulating hero-edge sparkline: observed line grows one point per frame; the
          held-out forecast lands as a dashed accent segment on the final frame. -->
-    <svg data-testid="sparkline" :viewBox="`0 0 ${SPARK.W} ${SPARK.H}`" width="100%">
+    <svg
+      data-testid="sparkline" :viewBox="`0 0 ${SPARK.W} ${SPARK.H}`"
+      width="100%" height="100%" preserveAspectRatio="xMidYMin meet"
+    >
       <line
         :x1="SPARK.padL" :y1="SPARK.H - SPARK.padB" :x2="SPARK.W - SPARK.padR"
         :y2="SPARK.H - SPARK.padB" stroke="#cbd5e1" stroke-width="1"
@@ -208,7 +211,7 @@ const spark = computed(() => {
       />
       <text
         v-for="(f, k) in dfgData.frames" :key="k"
-        :x="SPARK.X(k)" :y="SPARK.H - 6" text-anchor="middle" font-size="8" fill="#94a3b8"
+        :x="SPARK.X(k)" :y="SPARK.H - 6" text-anchor="middle" style="font-size: 8px" fill="#94a3b8"
       >t{{ k + 1 }}</text>
       <polyline
         data-testid="spark-line" fill="none" stroke="#0f172a" stroke-width="2"
@@ -226,7 +229,7 @@ const spark = computed(() => {
       />
       <text
         :x="spark.valLabel.x" :y="spark.valLabel.y" :text-anchor="spark.valLabel.anchor"
-        font-size="9" font-weight="700" :fill="spark.valLabel.fill"
+        style="font-size: 9px" font-weight="700" :fill="spark.valLabel.fill"
       >{{ spark.valLabel.text }}</text>
     </svg>
         </div>
@@ -245,11 +248,15 @@ const spark = computed(() => {
 /* Woven full-width layout, ported from prototypes/dfg-anim/layout.html (woven branch).
    Monochrome + the single KU Leuven accent (dfgData.accent #1d4ed8); no 3D, no shadows. */
 .dfg-evolution {
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
   height: 100%;
   min-height: 0;
+  /* Reserve the forecast-caption strip in every frame so the woven row never shifts
+     when step ④ appears on the forecast frame (the caption is absolutely positioned). */
+  padding-bottom: 22px;
   color: #0f172a;
   font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
 }
@@ -283,8 +290,8 @@ const spark = computed(() => {
   max-height: 160px;
 }
 .slot-spark {
-  flex: none;
-  height: 104px;
+  flex: 1;
+  min-height: 0;
 }
 .cap {
   font-size: 12px;
@@ -298,7 +305,10 @@ const spark = computed(() => {
   text-align: center;
 }
 .cap-forecast {
-  margin-top: 8px;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
   font-weight: 600;
   font-size: 12.5px;
 }

--- a/slides/template/components/dfgFrameState.js
+++ b/slides/template/components/dfgFrameState.js
@@ -5,7 +5,7 @@
 
 // sqrt scaling compresses the weight range so busy chain edges don't swamp the hero edge.
 export const strokeWidthFor = (weight, maxFreq) =>
-  Number((0.7 + 2.9 * Math.sqrt(weight / maxFreq)).toFixed(2))
+  Number((0.5 + 1.6 * Math.sqrt(weight / maxFreq)).toFixed(2))
 
 const INK = '#0f172a'
 const NEUTRAL = '#475569'

--- a/slides/template/components/dfgGeometry.js
+++ b/slides/template/components/dfgGeometry.js
@@ -15,7 +15,7 @@ export function trim(x1, y1, x2, y2, gapStart, gapEnd) {
 }
 
 // Frame-independent trimmed geometry [x1, y1, x2, y2] for every edge, keyed by edge id.
-export function edgeGeometry(nodes, edges, gapStart = 4.4, gapEnd = 4.8) {
+export function edgeGeometry(nodes, edges, gapStart = 4.4, gapEnd = 5.8) {
   const byId = Object.fromEntries(nodes.map((n) => [n.id, n]))
   return Object.fromEntries(
     edges.map((e) => {

--- a/slides/template/components/frameForClicks.js
+++ b/slides/template/components/frameForClicks.js
@@ -1,0 +1,5 @@
+// Maps Slidev's reactive `$clicks` counter to the DfgEvolution master frame index.
+// Slide 3 binds :frame="frameForClicks($clicks, dfgData.frames.length)".
+export function frameForClicks(clicks, frameCount) {
+  return Math.min(Math.max(clicks || 0, 0), frameCount - 1)
+}

--- a/slides/template/components/frameForClicks.test.js
+++ b/slides/template/components/frameForClicks.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { frameForClicks } from './frameForClicks.js'
+
+// Maps Slidev's reactive `$clicks` counter (0 on slide entry, +1 per click) to the
+// DfgEvolution master frame index, clamped to a valid frame. Slide 3 binds :frame to this.
+describe('frameForClicks — Slidev $clicks → DfgEvolution frame', () => {
+  it('opens on frame 0 (t₁) before any click', () => {
+    expect(frameForClicks(0, 4)).toBe(0)
+  })
+
+  it('advances one frame per click in lockstep', () => {
+    expect(frameForClicks(1, 4)).toBe(1)
+    expect(frameForClicks(2, 4)).toBe(2)
+  })
+
+  it('clamps at the forecast frame — extra clicks never overrun', () => {
+    expect(frameForClicks(3, 4)).toBe(3)
+    expect(frameForClicks(7, 4)).toBe(3)
+  })
+
+  it('floors junk input (negative or undefined $clicks) to frame 0', () => {
+    expect(frameForClicks(-1, 4)).toBe(0)
+    expect(frameForClicks(undefined, 4)).toBe(0)
+  })
+})

--- a/slides/template/slides.md
+++ b/slides/template/slides.md
@@ -69,40 +69,22 @@ PPM uses case prefixes. PMF uses something different — let me show you."
 -->
 
 ---
-layout: two-cols-header
+clicks: 3
 ---
+
+<script setup>
+import { frameForClicks } from './components/frameForClicks.js'
+import { dfgData } from './components/dfgData.js'
+</script>
 
 # From event log to DF time series
 
-::left::
-
-**Workflow**
-
-1. Event log  →  time-windowed sublogs
-2. Each window  →  a time-indexed DFG
-3. Each DF edge  →  one univariate time series
-4. Forecast next horizon  →  forecasted DFG
-
-<div class="mt-6 text-sm opacity-80">
-<em>Each DF edge becomes a univariate time series — like website traffic per day, but for one activity transition.</em>
+<div class="mt-2" style="height: 360px">
+  <DfgEvolution :frame="frameForClicks($clicks, dfgData.frames.length)" />
 </div>
 
-<div class="mt-2 text-sm opacity-60">
-We aggregate <strong>daily</strong>, forecast <strong>7 days</strong> ahead.
-</div>
-
-::right::
-
-<div class="border-2 border-dashed border-gray-400 rounded-lg p-4 flex items-center justify-center min-h-[300px]">
-<div class="text-center opacity-60 text-sm">
-[PLACEHOLDER]<br/>
-DFG-evolution animation<br/>
-(10–15s gif / Manim)<br/><br/>
-DFG at t₁ → t₂ → t₃<br/>
-↓<br/>
-forecasted DFG at t₄<br/>
-(predicted edges highlighted)
-</div>
+<div class="mt-3 text-sm opacity-70 text-center">
+Each DF edge becomes a univariate time series — we aggregate <strong>daily</strong>, forecast <strong>7 days</strong> ahead.
 </div>
 
 <!--


### PR DESCRIPTION
Closes #63.

Wires the woven `DfgEvolution` figure into slide 3 of the deck end-to-end and gets it presentable in `pnpm dev`.

## What changed
- **Slide 3 integration** — replaced the `[PLACEHOLDER]` with the full-width `DfgEvolution` figure (dropped `two-cols-header`), advanced by Slidev `v-click` via a tested `frameForClicks($clicks, frameCount)` helper (`clicks: 3` → frames t₁→t₄, climaxing on the forecast frame).
- **"window" reword** — slide 3 now uses weekly-snapshot language (the component's own ①②③④ captions: "weekly sublog" / "Each week → a time-indexed DFG"); no occurrence of the reserved term "window".
- **Outline** — Beat 2 records the approved full-width layout departure.

## In-slide rendering fixes & polish (on `DfgEvolution.vue`)
The component rendered correctly in its #62 unit tests but not in the actual slide; fixed here:
- Inline SVG `font-size` styles (a cascade rule was overriding the `font-size` presentation attributes → all in-figure text was oversized).
- Bounded figure height (the `h-[360px]` arbitrary class wasn't generated → figure sprawled).
- Sized the sparkline to its slot and top-aligned it; taller y-axis; title hugs the chart.
- Stabilised the forecast-frame ④ caption (absolutely positioned + reserved space) so the figure no longer jumps between frames — kept `v-if` so the existing tests hold.
- Thinned the DFG edge stroke; widened the arrowhead end-gap so heads clear the node boxes.

## Acceptance criteria (#63)
- [x] Slide 3 renders `DfgEvolution` full-width in place of the placeholder
- [x] Each `v-click` advances the master frame in lockstep (DFG, sparkline, log band, captions); final click reveals the forecast frame
- [x] Slide-3 left content uses weekly-snapshot language; no "window"
- [x] ≤15s of clicking (3 clicks); one question per slide
- [x] `outline.md` notes the full-width layout
- [x] #61/#62 tests still pass — **21/21 green** (17 existing + 4 new `frameForClicks` tests)

## Verification
- Visual: exported all four click states to PNG and inspected (light background — see note below).
- Tests: `pnpm test` → 21 passed.

## Deferred to the theme round (separate issue)
- Dark-background contrast: the palette is ink-on-white by design; the deck has no locked `colorSchema`, so it follows the viewer's system. Needs a deliberate light/dark decision + asset audit.
- Consolidate component colors into a single palette object (recoloring currently touches ~3 spots).