### PR TITLE
docs(slides): align dfg-anim make_data.py docstring with calm-story data

### DIFF
--- a/slides/template/prototypes/dfg-anim/make_data.py
+++ b/slides/template/prototypes/dfg-anim/make_data.py
@@ -5,12 +5,13 @@ Bake the shared DFG-evolution frame data that all four pipeline prototypes
 *identical* real numbers and only the rendering differs.
 
 Story: bpi2017 "offer" subgraph. Three observed weeks (t1..t3) then a forecast
-week (t4). Every edge is stable except the hero edge `Sent -> Cancelled`, whose
-weekly frequency collapses 281 -> 262 -> 88 (an edge-specific behavioural drift,
-the same O_Sent->O_Cancelled drift used on slides 2 and 4). The forecast frame is
-an illustrative naive-persistence forecast (= last observed week); the held-out
-ground truth for that week is kept so the asset can ghost it behind the
-accent-blue prediction.
+week (t4). A calm mid-series stretch (Oct 02-23) with gentle week-to-week
+variation on the hero edge `Sent -> Cancelled` (346 -> 314 -> 316) -- capability
+framing, NOT the dramatic drift reserved for slides 4/7b. The forecast frame is an
+illustrative naive-persistence forecast (= last observed week, 316); the held-out
+ground truth (315) is kept so the asset can ghost it behind the accent-blue
+prediction -- the forecast lands on the truth, showing we can predict next week's
+whole DFG.
 
 Run:  uv run python slides/template/prototypes/dfg-anim/make_data.py
 """


### PR DESCRIPTION
## What

The `make_data.py` module docstring in `slides/template/prototypes/dfg-anim/` was the only artifact left narrating the **old** dramatic-drift story (hero edge `Sent -> Cancelled` collapsing **281 -> 262 -> 88**), while everything else in the directory had already moved to the **calm mid-series capability framing**:

| Artifact | State on `main` |
|---|---|
| `WEEKS` array (Oct 02-23) | calm window |
| inline comment (L54-56) | 346 -> 314 -> 316 |
| baked `data.json` / `data.js` | 346 -> 314 -> 316, forecast 316 vs truth 315 |
| slide 3 / `DfgEvolution` (#75) | calm capability framing |
| `NOTES.md` Round 2 | "Calm Oct stretch... No dramatic collapse — that's slide 4" |
| **module docstring (L7-13)** | **stale: 281 -> 262 -> 88** ← fixed here |

## Why

This edit originated as an orphaned working-tree change from a concurrent-session collision; the slide-3 PR (#75) merged without it, leaving `make_data.py` internally contradicting its own data. This restores consistency.

## Scope

Prose-only — **data is unchanged**. `data.json`/`data.js` already encode the calm numbers, so no regeneration is needed and slides 4/7b (which own the dramatic-drift story) are untouched.