### PR TITLE
feat(demo): diff view interpretability — bicolour weights + legend (#74)

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -27,8 +27,14 @@ MODELS: list[str] = ["chronos2"]
 
 
 def _scrollable(svg: str) -> str:
-    """Wrap a rendered SVG so it scrolls within its pane."""
-    return f'<div style="overflow:auto; max-height:70vh">{svg}</div>'
+    """Wrap a rendered SVG so it scrolls within its pane, centred horizontally.
+
+    Gradio renders ``<svg>`` as ``display:block``, so it ignores ``text-align``;
+    ``margin:0 auto`` on the element itself centres it when it is narrower than the
+    pane, while ``overflow:auto`` keeps a wider graph fully scrollable.
+    """
+    centred = svg.replace("<svg ", '<svg style="display:block;margin:0 auto" ', 1)
+    return f'<div style="overflow:auto; max-height:70vh">{centred}</div>'
 
 
 def _pane(dfg: dict[str, Any]) -> str:

--- a/demo/dfg_diff.py
+++ b/demo/dfg_diff.py
@@ -38,16 +38,23 @@ def dfg_diff(
 
     Returns:
         ``{"matched": [...], "added": [...], "removed": [...]}`` where each entry
-        is ``{"from": label, "to": label, "freq": int}``. ``matched``/``added``
-        carry the actual weight; ``removed`` carries the forecast weight.
+        is ``{"from": label, "to": label, "forecast_freq": int, "actual_freq":
+        int}``. Every entry carries *both* weights as a ``forecast → actual``
+        transition; the side where the relation is absent is ``0`` (so ``added``
+        has ``forecast_freq == 0`` and ``removed`` has ``actual_freq == 0``).
     """
     forecast = _relations(forecast_dfg)
     actual = _relations(actual_dfg)
 
-    def entry(rel: tuple[str, str], freq: int) -> dict[str, Any]:
-        return {"from": rel[0], "to": rel[1], "freq": freq}
+    def entry(rel: tuple[str, str]) -> dict[str, Any]:
+        return {
+            "from": rel[0],
+            "to": rel[1],
+            "forecast_freq": forecast.get(rel, 0),
+            "actual_freq": actual.get(rel, 0),
+        }
 
-    matched = [entry(rel, actual[rel]) for rel in actual if rel in forecast]
-    added = [entry(rel, actual[rel]) for rel in actual if rel not in forecast]
-    removed = [entry(rel, forecast[rel]) for rel in forecast if rel not in actual]
+    matched = [entry(rel) for rel in actual if rel in forecast]
+    added = [entry(rel) for rel in actual if rel not in forecast]
+    removed = [entry(rel) for rel in forecast if rel not in actual]
     return {"matched": matched, "added": added, "removed": removed}

--- a/demo/render.py
+++ b/demo/render.py
@@ -25,6 +25,38 @@ _MATCHED_COLOUR = "#9e9e9e"
 _ADDED_COLOUR = "#ffb300"
 _REMOVED_COLOUR = "#e53935"
 
+# Each arc label shows two numbers — the forecast weight and the actual weight —
+# distinguished by colour rather than by an arrow, so a reader can tell at a
+# glance which side is which (a 0 means the relation is absent on that side).
+_FORECAST_COLOUR = "#1e88e5"  # blue
+_ACTUAL_COLOUR = "#2e7d32"  # green
+_SEP_COLOUR = "#bdbdbd"  # faint separator between the two numbers
+
+# Embedded legend rows: (line-sample HTML, meaning). The sample is a short glyph
+# in that class's colour — a solid rule for matched, dashes for the changed
+# classes — so a first-time reader can map line colour/style to meaning. The
+# samples are padded to a similar visual width so the column stays aligned.
+_LEGEND_ROWS = [
+    (f'<FONT COLOR="{_MATCHED_COLOUR}">&#9472;&#9472;&#9472;&#9472;&#9472;</FONT>', "matched"),
+    (
+        f'<FONT COLOR="{_ADDED_COLOUR}">&#8211; &#8211; &#8211;</FONT>',
+        "happened &#8212; forecast missed it",
+    ),
+    (
+        f'<FONT COLOR="{_REMOVED_COLOUR}">&#8211; &#8211; &#8211;</FONT>',
+        "forecast predicted it &#8212; did not happen",
+    ),
+]
+
+
+def _arc_label(forecast_freq: int, actual_freq: int) -> str:
+    """HTML-like edge label: forecast weight (blue) · actual weight (green)."""
+    return (
+        f'<<FONT COLOR="{_FORECAST_COLOUR}">{forecast_freq}</FONT>'
+        f'<FONT COLOR="{_SEP_COLOUR}">&#160;|&#160;</FONT>'
+        f'<FONT COLOR="{_ACTUAL_COLOUR}">{actual_freq}</FONT>>'
+    )
+
 
 def dfg_json_to_svg(dfg: dict[str, Any]) -> str:
     """Render a DFG JSON document to an SVG string.
@@ -72,12 +104,48 @@ def diff_svg(forecast_dfg: dict[str, Any], actual_dfg: dict[str, Any]) -> str:
     for label in labels:
         graph.node(label, label=label)
 
+    # De-emphasize the unchanged backbone (thin grey) so the amber/red changed
+    # arcs (thicker) dominate.
     styling = {
-        "matched": {"color": _MATCHED_COLOUR},
-        "added": {"color": _ADDED_COLOUR, "style": "dashed"},
-        "removed": {"color": _REMOVED_COLOUR, "style": "dashed"},
+        "matched": {"color": _MATCHED_COLOUR, "penwidth": "1.0"},
+        "added": {"color": _ADDED_COLOUR, "style": "dashed", "penwidth": "2.5"},
+        "removed": {"color": _REMOVED_COLOUR, "style": "dashed", "penwidth": "2.5"},
     }
     for diff_class, entries in diff.items():
         for entry in entries:
-            graph.edge(entry["from"], entry["to"], label=str(entry["freq"]), **styling[diff_class])
+            label = _arc_label(entry["forecast_freq"], entry["actual_freq"])
+            graph.edge(entry["from"], entry["to"], label=label, **styling[diff_class])
+
+    _add_legend(graph)
     return graph.pipe(format="svg").decode("utf-8")
+
+
+def _add_legend(graph: graphviz.Digraph) -> None:
+    """Embed a compact key as a single HTML-table node in its own cluster.
+
+    The table has two parts: a forecast/actual number-colour key (explaining the
+    bicolour edge labels) and one row per diff class pairing a line sample with
+    its meaning. A single table keeps the legend tight instead of sprawling.
+    """
+    # The forecast/actual number-colour key spans the full width on its own row,
+    # so it does not widen the line-sample column and throw the grid off.
+    number_key = (
+        '<FONT COLOR="#555555">edge numbers: </FONT>'
+        f'<FONT COLOR="{_FORECAST_COLOUR}">forecast</FONT>'
+        f'<FONT COLOR="{_SEP_COLOUR}">&#160;|&#160;</FONT>'
+        f'<FONT COLOR="{_ACTUAL_COLOUR}">actual</FONT>'
+    )
+    # The three diff classes form an aligned 2-column grid: line sample | meaning.
+    class_rows = "".join(
+        f'<TR><TD ALIGN="LEFT">{sample}</TD><TD ALIGN="LEFT">{meaning}</TD></TR>'
+        for sample, meaning in _LEGEND_ROWS
+    )
+    table = (
+        '<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3">'
+        '<TR><TD COLSPAN="2" ALIGN="CENTER"><B>Legend</B></TD></TR>'
+        f'<TR><TD COLSPAN="2" ALIGN="LEFT">{number_key}</TD></TR>'
+        f"{class_rows}</TABLE>>"
+    )
+    with graph.subgraph(name="cluster_legend") as legend:
+        legend.attr(color="#bdbdbd", style="dashed")
+        legend.node("_legend", label=table, shape="plaintext")

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -120,8 +120,8 @@ def test_dfg_diff_disjoint_all_added_and_removed():
     assert _rels(diff["added"]) == {("▶", "Y")}
 
 
-def test_dfg_diff_partial_overlap_is_label_keyed_with_directional_freq():
-    """Relations key on labels (not ids); freq comes from the right DFG."""
+def test_dfg_diff_partial_overlap_is_label_keyed_with_both_freqs():
+    """Relations key on labels (not ids); every entry carries both weights."""
     forecast = {
         "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "C", "id": 2}],
         "arcs": [
@@ -142,10 +142,13 @@ def test_dfg_diff_partial_overlap_is_label_keyed_with_directional_freq():
     assert _rels(diff["matched"]) == {("A", "B")}
     assert _rels(diff["added"]) == {("B", "D")}
     assert _rels(diff["removed"]) == {("B", "C")}
-    # matched/added carry the actual weight; removed carries the forecast weight.
-    assert diff["matched"][0]["freq"] == 9
-    assert diff["added"][0]["freq"] == 2
-    assert diff["removed"][0]["freq"] == 7
+    # Every entry exposes both weights; the absent side is 0.
+    assert diff["matched"][0]["forecast_freq"] == 4
+    assert diff["matched"][0]["actual_freq"] == 9
+    assert diff["added"][0]["forecast_freq"] == 0  # forecast missed it
+    assert diff["added"][0]["actual_freq"] == 2
+    assert diff["removed"][0]["forecast_freq"] == 7
+    assert diff["removed"][0]["actual_freq"] == 0  # it did not happen
 
 
 def test_dfg_diff_handles_start_end_marker_relations():
@@ -209,6 +212,67 @@ def test_diff_svg_colour_codes_the_three_diff_classes():
     assert all("stroke-dasharray" in p for p in stroke_paths(amber))  # added dashed
     assert all("stroke-dasharray" in p for p in stroke_paths(red))  # removed dashed
     assert all("stroke-dasharray" not in p for p in stroke_paths(grey))  # matched solid
+
+
+# A drifting forecast/actual pair: A->B matched (4,9), B->D added (0,2, forecast
+# missed it), B->C removed (7,0, predicted but didn't happen).
+DRIFT_FORECAST = {
+    "nodes": [{"label": "A", "id": 0}, {"label": "B", "id": 1}, {"label": "C", "id": 2}],
+    "arcs": [{"from": 0, "to": 1, "freq": 4}, {"from": 1, "to": 2, "freq": 7}],
+}
+DRIFT_ACTUAL = {
+    "nodes": [{"label": "A", "id": 5}, {"label": "B", "id": 6}, {"label": "D", "id": 7}],
+    "arcs": [{"from": 5, "to": 6, "freq": 9}, {"from": 6, "to": 7, "freq": 2}],
+}
+
+# Edge numbers are colour-coded by side (forecast vs actual), not joined by "→".
+FORECAST_COLOUR = "#1e88e5"  # blue
+ACTUAL_COLOUR = "#2e7d32"  # green
+
+
+def test_diff_svg_labels_arcs_with_bicolour_forecast_actual():
+    """Each arc shows its forecast weight and actual weight as two distinctly
+    coloured numbers (forecast = blue, actual = green) — no "→" join."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL)
+    # matched A->B: forecast 4 (blue), actual 9 (green).
+    assert re.search(rf'fill="{FORECAST_COLOUR}"[^>]*>4<', svg)
+    assert re.search(rf'fill="{ACTUAL_COLOUR}"[^>]*>9<', svg)
+    # added B->D: forecast 0 (blue, it missed it), actual 2 (green).
+    assert re.search(rf'fill="{FORECAST_COLOUR}"[^>]*>0<', svg)
+    assert re.search(rf'fill="{ACTUAL_COLOUR}"[^>]*>2<', svg)
+    # The arrow join is gone — colour carries the forecast/actual distinction.
+    assert "→" not in svg
+
+
+def _stroke_width(svg, colour):
+    """The stroke-width of the first ``colour`` edge path (1.0 if unset)."""
+    path = re.search(rf'<path[^>]*stroke="{colour}"[^>]*?/>', svg).group(0)
+    m = re.search(r'stroke-width="([\d.]+)"', path)
+    return float(m.group(1)) if m else 1.0
+
+
+def test_diff_svg_deemphasizes_matched_arcs():
+    """Matched arcs are thinner than the amber/red changed arcs, so drift pops
+    against the unchanged backbone."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL)
+    grey, amber, red = "#9e9e9e", "#ffb300", "#e53935"
+    matched = _stroke_width(svg, grey)
+    assert matched < _stroke_width(svg, amber)  # added stands out
+    assert matched < _stroke_width(svg, red)  # removed stands out
+
+
+def test_diff_svg_embeds_legend():
+    """The diff graph carries an embedded legend explaining both the three
+    line-style classes and the forecast/actual number colours."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL)
+    assert "Legend" in svg
+    # The three diff classes, in forecast-centric wording.
+    assert "matched" in svg
+    assert "missed it" in svg  # amber: it happened but the forecast missed it
+    assert "did not happen" in svg  # red: predicted but it did not happen
+    # The forecast/actual number-colour key (so the bicolour edge labels read).
+    assert "forecast" in svg and "actual" in svg
+    assert FORECAST_COLOUR in svg and ACTUAL_COLOUR in svg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Makes the Diff view (#68) legible for a first-time reader — the magnitude of drift and the colour semantics are now self-explanatory. Closes #74.

Three interpretability improvements, all on the Diff view:

1. **Per-arc weight comparison.** `dfg_diff` entries now carry **both** `forecast_freq` and `actual_freq` (absent side = `0`), unifying matched/added/removed under one forecast→actual transition model. `diff_svg` labels each arc with **two colour-coded numbers** — forecast (blue) and actual (green) — instead of an arrow, so it's obvious which side is which.
2. **Emphasis.** Matched arcs are de-emphasized (thin grey, `penwidth 1.0`); changed arcs (amber/red, `penwidth 2.5`) dominate, so drift pops against the unchanged backbone.
3. **Embedded legend.** A compact HTML-table legend with a forecast/actual number-colour key plus the three line-style classes (grey solid = matched · amber dashed = happened, forecast missed it · red dashed = forecast predicted it, did not happen).

Also: each SVG pane is now centred horizontally (`margin:0 auto` on the `<svg>`, since gradio renders it `display:block`).

The `dfg_diff` two-weight contract change also benefits the slice-2 upload drift descriptors.

## Test plan

- `uv run pytest` — **288 pass** (4 demo tests added/updated: bicolour arc labels, legend content + colour key, both-weights contract; de-emphasis stroke-width).
- `ruff check` + `ruff format --check` — clean.
- Live GUI verified (gradio + Playwright): Side-by-side ↔ Diff toggle, bicolour `forecast | actual` edge labels, de-emphasized matched arcs, aligned legend, centred panes; metrics strip unchanged.