### PR TITLE
fix(slides): polish DfgEvolution figure — arrows, step-③ caption, node-label fit

### DIFF
--- a/slides/template/components/DfgEvolution.test.js
+++ b/slides/template/components/DfgEvolution.test.js
@@ -3,8 +3,8 @@ import { mount } from '@vue/test-utils'
 import DfgEvolution from './DfgEvolution.vue'
 
 // Stroke width for an edge weight:
-// scaleW(f) = 0.5 + 1.6 * sqrt(f / max_freq), max_freq = 927.
-const expectedWidth = (f) => 0.5 + 1.6 * Math.sqrt(f / 927)
+// scaleW(f) = 0.55 + 1.15 * sqrt(f / max_freq), max_freq = 927.
+const expectedWidth = (f) => 0.55 + 1.15 * Math.sqrt(f / 927)
 
 const heroWidth = (wrapper) =>
   Number(wrapper.get('[data-edge="sent__cancelled"]').attributes('stroke-width'))
@@ -64,6 +64,16 @@ describe('DfgEvolution — frame choreography', () => {
     }
     await wrapper.setProps({ frame: 3 })
     expect(allForecastFlags().every((f) => f === 'true')).toBe(true)
+  })
+
+  it('renders each DFG edge with a separate arrowhead, not an SVG marker overlay', () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 2 } })
+    const edgeShafts = wrapper.findAll('[data-edge]')
+    const edgeHeads = wrapper.findAll('[data-edge-head]')
+
+    expect(edgeShafts).toHaveLength(8)
+    expect(edgeHeads).toHaveLength(8)
+    expect(edgeShafts.every((edge) => edge.attributes('marker-end') === undefined)).toBe(true)
   })
 
   it('renders every DFG node, with activity labels shown', () => {

--- a/slides/template/components/DfgEvolution.vue
+++ b/slides/template/components/DfgEvolution.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { dfgData } from './dfgData.js'
 import { frameState } from './dfgFrameState.js'
-import { edgeGeometry, sparkScale } from './dfgGeometry.js'
+import { arrowGeometry, edgeGeometry, sparkScale } from './dfgGeometry.js'
 
 // `frame` is the master index; slice #3 will bind it to Slidev v-click.
 const props = defineProps({
@@ -12,7 +12,20 @@ const props = defineProps({
 const state = computed(() => frameState(dfgData, props.frame))
 
 // Frame-independent trimmed geometry [x1,y1,x2,y2] for every edge, keyed by edge id.
-const edgeGeo = edgeGeometry(dfgData.nodes, dfgData.edges)
+// The hero edge is the one long diagonal into a wide box, so the shared radial end gap
+// leaves its arrowhead overlapping the (dashed, on the forecast frame) body at the box
+// border — pull just its end back to clear the Cancelled box.
+const edgeGeo = edgeGeometry(dfgData.nodes, dfgData.edges, 4.4, 5.8, { [dfgData.hero]: 14 })
+
+const edgeDraw = computed(() =>
+  Object.fromEntries(dfgData.edges.map((edge) => [
+    edge.id,
+    arrowGeometry(edgeGeo[edge.id], state.value.edges[edge.id].strokeWidth),
+  ])),
+)
+const heroGhostDraw = computed(() =>
+  arrowGeometry(edgeGeo[dfgData.hero], state.value.heroGhost.strokeWidth || 1),
+)
 
 // Workflow captions woven under each part of the figure (per render_diagram.js STEPS).
 // "weekly sublog" / "weekly snapshot" wording avoids the reserved term "window" (ER only).
@@ -124,36 +137,33 @@ const spark = computed(() => {
       <div class="wcol wcol-dfg">
         <div class="slot">
     <svg viewBox="0 0 100 104" width="100%" height="100%">
-      <defs>
-        <marker
-          v-for="m in [{ id: 'arrow', col: '#475569' }, { id: 'arrowA', col: dfgData.accent }]"
-          :key="m.id" :id="m.id" viewBox="0 0 10 10" refX="8" refY="5"
-          markerWidth="2.8" markerHeight="2.8" orient="auto-start-reverse"
-          markerUnits="userSpaceOnUse"
-        >
-          <path d="M0,0 L10,5 L0,10 z" :fill="m.col" />
-        </marker>
-      </defs>
-      <line
+      <g
         v-for="edge in dfgData.edges"
         :key="edge.id"
-        :data-edge="edge.id"
-        :data-forecast="state.edges[edge.id].isForecast"
-        :x1="edgeGeo[edge.id][0]" :y1="edgeGeo[edge.id][1]"
-        :x2="edgeGeo[edge.id][2]" :y2="edgeGeo[edge.id][3]"
-        fill="none" stroke-linecap="round"
-        :stroke-width="state.edges[edge.id].strokeWidth"
-        :stroke="state.edges[edge.id].stroke"
-        :marker-end="`url(#${state.edges[edge.id].marker})`"
-        :stroke-dasharray="state.edges[edge.id].dashed ? '2.4 1.8' : '0'"
-      />
+      >
+        <line
+          :data-edge="edge.id"
+          :data-forecast="state.edges[edge.id].isForecast"
+          :x1="edgeDraw[edge.id].shaft[0]" :y1="edgeDraw[edge.id].shaft[1]"
+          :x2="edgeDraw[edge.id].shaft[2]" :y2="edgeDraw[edge.id].shaft[3]"
+          fill="none" stroke-linecap="butt"
+          :stroke-width="state.edges[edge.id].strokeWidth"
+          :stroke="state.edges[edge.id].stroke"
+          :stroke-dasharray="state.edges[edge.id].dashed ? '2.4 1.8' : '0'"
+        />
+        <path
+          :data-edge-head="edge.id"
+          :d="edgeDraw[edge.id].headPath"
+          :fill="state.edges[edge.id].stroke"
+        />
+      </g>
       <!-- Held-out-truth ghost over the hero edge, forecast frame only. -->
       <line
         v-if="state.heroGhost.visible"
         data-testid="hero-ghost"
-        :x1="edgeGeo[dfgData.hero][0]" :y1="edgeGeo[dfgData.hero][1]"
-        :x2="edgeGeo[dfgData.hero][2]" :y2="edgeGeo[dfgData.hero][3]"
-        fill="none" stroke="#94a3b8" stroke-linecap="round" opacity="0.6"
+        :x1="heroGhostDraw.shaft[0]" :y1="heroGhostDraw.shaft[1]"
+        :x2="heroGhostDraw.shaft[2]" :y2="heroGhostDraw.shaft[3]"
+        fill="none" stroke="#94a3b8" stroke-linecap="butt" opacity="0.6"
         :stroke-width="state.heroGhost.strokeWidth"
       />
       <!-- Hero-edge weight readout, offset from the edge midpoint. -->
@@ -167,12 +177,12 @@ const spark = computed(() => {
       <g v-for="node in dfgData.nodes" :key="node.id" :data-node="node.id">
         <template v-if="node.kind === 'activity'">
           <rect
-            :x="node.x - 10.5" :y="node.y - 3.6" width="21" height="7.2" rx="2.2"
+            :x="node.x - 12" :y="node.y - 3.6" width="24" height="7.2" rx="2.2"
             fill="#ffffff" stroke="#cbd5e1" stroke-width="0.5"
           />
           <text
             :x="node.x" :y="node.y + 1.3" text-anchor="middle"
-            style="font-size: 3.4px" fill="#0f172a"
+            style="font-size: 3.2px" fill="#0f172a"
           >{{ node.label }}</text>
         </template>
         <circle
@@ -233,7 +243,7 @@ const spark = computed(() => {
       >{{ spark.valLabel.text }}</text>
     </svg>
         </div>
-        <div data-testid="step-3" class="cap">{{ STEPS[2] }}</div>
+        <div data-testid="step-3" class="cap cap-left">{{ STEPS[2] }}</div>
       </div>
     </div>
 
@@ -275,6 +285,9 @@ const spark = computed(() => {
   justify-content: center;
   gap: 6px;
 }
+.wcol-spark {
+  justify-content: flex-start;
+}
 .warrow {
   display: flex;
   align-items: center;
@@ -290,7 +303,7 @@ const spark = computed(() => {
   max-height: 160px;
 }
 .slot-spark {
-  flex: 1;
+  flex: 0 0 62%;
   min-height: 0;
 }
 .cap {
@@ -298,6 +311,11 @@ const spark = computed(() => {
   color: #475569;
   text-align: center;
   line-height: 1.35;
+}
+/* Step ③ mirrors step ①: left-aligned to the column edge, not centred under the plot. */
+.cap-left {
+  text-align: left;
+  white-space: nowrap;
 }
 .spark-title {
   font-size: 11px;

--- a/slides/template/components/dfgFrameState.js
+++ b/slides/template/components/dfgFrameState.js
@@ -2,9 +2,9 @@
 // Maps a frame index to the derived view-state the component renders. No DOM, no Vue —
 // this is the deep module the component is a thin shell around.
 
-// sqrt scaling compresses the weight range so busy chain edges don't swamp the hero edge.
+// sqrt scaling compresses the weight range without letting busy chain edges swamp arrowheads.
 export const strokeWidthFor = (weight, maxFreq) =>
-  Number((0.5 + 1.6 * Math.sqrt(weight / maxFreq)).toFixed(2))
+  Number((0.55 + 1.15 * Math.sqrt(weight / maxFreq)).toFixed(2))
 
 const INK = '#0f172a'
 const NEUTRAL = '#475569'

--- a/slides/template/components/dfgGeometry.js
+++ b/slides/template/components/dfgGeometry.js
@@ -15,15 +15,47 @@ export function trim(x1, y1, x2, y2, gapStart, gapEnd) {
 }
 
 // Frame-independent trimmed geometry [x1, y1, x2, y2] for every edge, keyed by edge id.
-export function edgeGeometry(nodes, edges, gapStart = 4.4, gapEnd = 5.8) {
+// `endGaps` overrides the end gap per edge id — used to pull the long diagonal hero edge
+// back far enough to clear its wide target box (a global gapEnd bump would erase the short
+// vertical edges instead).
+export function edgeGeometry(nodes, edges, gapStart = 4.4, gapEnd = 5.8, endGaps = {}) {
   const byId = Object.fromEntries(nodes.map((n) => [n.id, n]))
   return Object.fromEntries(
     edges.map((e) => {
       const s = byId[e.source]
       const t = byId[e.target]
-      return [e.id, trim(s.x, s.y, t.x, t.y, gapStart, gapEnd)]
+      return [e.id, trim(s.x, s.y, t.x, t.y, gapStart, endGaps[e.id] ?? gapEnd)]
     }),
   )
+}
+
+// Arrowhead geometry for one already-trimmed edge. The shaft ends at the head base so
+// thick weight-scaled strokes never run underneath the arrowhead.
+export function arrowGeometry(segment, strokeWidth) {
+  const [x1, y1, x2, y2] = segment
+  const dx = x2 - x1
+  const dy = y2 - y1
+  const L = Math.hypot(dx, dy) || 1
+  const ux = dx / L
+  const uy = dy / L
+  const arrowLen = Math.min(Math.max(2.4, strokeWidth * 1.65), Math.max(0.8, L * 0.55))
+  const halfWidth = Math.min(Math.max(1.15, strokeWidth * 0.95), arrowLen * 0.78)
+  const baseX = x2 - ux * arrowLen
+  const baseY = y2 - uy * arrowLen
+  const nx = -uy
+  const ny = ux
+
+  return {
+    shaft: [x1, y1, baseX, baseY],
+    headPath: [
+      `M ${x2} ${y2}`,
+      `L ${baseX + nx * halfWidth} ${baseY + ny * halfWidth}`,
+      `L ${baseX - nx * halfWidth} ${baseY - ny * halfWidth}`,
+      'Z',
+    ].join(' '),
+    tip: [x2, y2],
+    base: [baseX, baseY],
+  }
 }
 
 // Sparkline coordinate scales (render_diagram.js buildSpark). The data-centred y-range shows

--- a/slides/template/components/dfgGeometry.test.js
+++ b/slides/template/components/dfgGeometry.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { trim, edgeGeometry, sparkScale } from './dfgGeometry.js'
+import { arrowGeometry, trim, edgeGeometry, sparkScale } from './dfgGeometry.js'
 import { dfgData } from './dfgData.js'
 
 describe('dfgGeometry — pure layout helpers', () => {
@@ -19,6 +19,38 @@ describe('dfgGeometry — pure layout helpers', () => {
     for (const id of Object.keys(geo)) {
       expect(geo[id]).toHaveLength(4)
       expect(geo[id].every(Number.isFinite)).toBe(true)
+    }
+  })
+
+  it('applies a per-edge end-gap override, leaving other edges on the default gap', () => {
+    // The long diagonal hero edge ends inside the wide Cancelled box on the shared radial
+    // gap; an override pulls just its end back to clear the box (without touching the short
+    // vertical edges, which a global gap bump would erase).
+    const byId = Object.fromEntries(dfgData.nodes.map((n) => [n.id, n]))
+    const endDist = (geo, edgeId, targetId) => {
+      const t = byId[targetId]
+      return Math.hypot(geo[edgeId][2] - t.x, geo[edgeId][3] - t.y)
+    }
+    const base = edgeGeometry(dfgData.nodes, dfgData.edges)
+    const over = edgeGeometry(dfgData.nodes, dfgData.edges, 4.4, 5.8, { sent__cancelled: 14 })
+
+    // hero edge end is pulled back from 5.8 → 14 away from the Cancelled centre
+    expect(endDist(base, 'sent__cancelled', 'cancelled')).toBeCloseTo(5.8, 5)
+    expect(endDist(over, 'sent__cancelled', 'cancelled')).toBeCloseTo(14, 5)
+    // a non-overridden edge is untouched
+    expect(over.created__sent).toEqual(base.created__sent)
+  })
+
+  it('ends each arrow shaft before the arrowhead tip', () => {
+    const geo = edgeGeometry(dfgData.nodes, dfgData.edges, 4.4, 5.8, { sent__cancelled: 14 })
+    for (const edge of dfgData.edges) {
+      const arrow = arrowGeometry(geo[edge.id], 2)
+      const [tipX, tipY] = arrow.tip
+      const [baseX, baseY] = arrow.base
+      const tipDist = Math.hypot(tipX - baseX, tipY - baseY)
+      expect(tipDist).toBeGreaterThan(0.75)
+      expect(arrow.shaft.slice(2)).toEqual(arrow.base)
+      expect(arrow.headPath).toContain('Z')
     }
   })
 


### PR DESCRIPTION
Three cosmetic polish fixes to the slide-3 DfgEvolution figure (surfaced during deck
review; tracked separately from the #64 cleanup).

1. Forecast-edge arrow overlap — each edge now draws a shaft + separate arrowhead
   path (SVG markers removed); edge stroke scale reduced. Hero edge keeps its
   end-gap override to clear the Cancelled box.
2. Step-③ caption — left-aligned on the upper rail, mirroring step ①.
3. Node-label fit — activity rects enlarged, label font trimmed (e.g. Create Offer).

Verified: `pnpm test` (24 passed), `pnpm build` clean, and slide-3 PNG export across all
click states (observed + forecast frames).

Closes #78
