### PR TITLE
feat(slides): slide-3 DfgEvolution — daily-fidelity right panel + faithful pipeline reframe (#84)

### DIFF
--- a/slides/talk_design/outline.md
+++ b/slides/talk_design/outline.md
@@ -42,8 +42,9 @@ For brief / hard constraints / spoken lines, see `../SLIDES.md`.
 **Audience Q answered:** "How does PMF become a forecasting problem?"
 **Transition in:** *"Both questions need data. PPM uses case prefixes. PMF uses something different."*
 **Slide content:**
-- Workflow diagram: event log → time-windowed sublogs → time-indexed DFGs →
-  each DF edge becomes a univariate time series
+- Workflow diagram: event log → daily DF counts (one univariate series per DF edge) →
+  forecast 7 daily steps → Σ over the horizon → next week's DFG
+  (each week's DFG is the Σ-aggregate of daily counts, not a weekly-extracted object)
 - **Embedded DFG-evolution animation** (10–15s gif/Manim): DFG at t₁, t₂, t₃ →
   forecasted DFG at t₄ with predicted edges highlighted in accent color
 - One sentence: *"Each DF edge becomes a univariate time series — like website

--- a/slides/template/components/DfgEvolution.test.js
+++ b/slides/template/components/DfgEvolution.test.js
@@ -25,11 +25,11 @@ describe('DfgEvolution — frame choreography', () => {
     }
   })
 
-  it('accumulates one sparkline point per frame (i+1)', async () => {
+  it('reveals one week (7 daily points) of the sparkline per frame', async () => {
     const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
     for (let i = 0; i < 4; i++) {
       await wrapper.setProps({ frame: i })
-      expect(wrapper.findAll('[data-testid="spark-point"]')).toHaveLength(i + 1)
+      expect(wrapper.findAll('[data-testid="spark-point"]')).toHaveLength((i + 1) * 7)
     }
   })
 
@@ -144,6 +144,19 @@ describe('DfgEvolution — frame choreography', () => {
     }
   })
 
+  it('frames the daily series as primary and the weekly DFG as its Σ-aggregate, not weekly-first extraction', () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const step1 = wrapper.get('[data-testid="step-1"]').text().toLowerCase()
+    const step2 = wrapper.get('[data-testid="step-2"]').text()
+
+    // ① the primary extraction is the daily series, not a weekly sublog
+    expect(step1).toContain('daily')
+    expect(step1).not.toContain('sublog')
+    // ② the weekly DFG reads as the Σ-aggregate of the daily counts
+    expect(step2).toContain('Σ')
+    expect(step2.toLowerCase()).toContain('daily')
+  })
+
   it('slides the event-log band right one constant week-step per frame', async () => {
     const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
     const translateX = () => {
@@ -161,18 +174,40 @@ describe('DfgEvolution — frame choreography', () => {
     }
   })
 
-  it('accumulates the observed sparkline and draws the dashed forecast segment only at the end', async () => {
+  it('accumulates the daily observed line and draws the 7-day dashed forecast tail only at the end', async () => {
     const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
-    const obsCount = () =>
-      wrapper.get('[data-testid="spark-line"]').attributes('points').trim().split(/\s+/).length
+    const pointCount = (sel) => {
+      const el = wrapper.find(sel)
+      if (!el.exists()) return 0
+      return el.attributes('points').trim().split(/\s+/).length
+    }
     const forecastSeg = () => wrapper.find('[data-testid="spark-forecast"]')
 
-    // observed polyline grows one point per observed frame; the forecast point is NOT on it
-    const expectedObs = [1, 2, 3, 3] // t₁..t₃ observed; t₄ forecast keeps the 3 observed
+    // observed polyline grows one week (7 daily points) per observed frame; the 7 forecast
+    // days are NOT on it — they land as the dashed accent tail on the forecast frame.
+    const expectedObs = [7, 14, 21, 21] // t₁..t₃ observed; t₄ forecast keeps the 21 observed
     for (let i = 0; i < 4; i++) {
       await wrapper.setProps({ frame: i })
-      expect(obsCount()).toBe(expectedObs[i])
+      expect(pointCount('[data-testid="spark-line"]')).toBe(expectedObs[i])
       expect(forecastSeg().exists()).toBe(i === 3)
     }
+    // the forecast horizon is exactly the 7 daily prediction steps
+    expect(pointCount('[data-testid="spark-forecast"]')).toBe(7)
+  })
+
+  it('shows the Σ rollup readout only on the forecast frame, matching the weekly forecast-DFG arc', async () => {
+    const wrapper = mount(DfgEvolution, { props: { frame: 0 } })
+    const sum = () => wrapper.find('[data-testid="spark-sum"]')
+
+    // observed frames carry no rollup readout
+    for (const i of [0, 1, 2]) {
+      await wrapper.setProps({ frame: i })
+      expect(sum().exists()).toBe(false)
+    }
+    // forecast frame announces the 7 daily forecasts summing to the weekly arc (≈316)
+    await wrapper.setProps({ frame: 3 })
+    expect(sum().exists()).toBe(true)
+    expect(sum().text()).toContain('Σ')
+    expect(sum().text()).toContain('316')
   })
 })

--- a/slides/template/components/DfgEvolution.vue
+++ b/slides/template/components/DfgEvolution.vue
@@ -28,12 +28,14 @@ const heroGhostDraw = computed(() =>
 )
 
 // Workflow captions woven under each part of the figure (per render_diagram.js STEPS).
-// "weekly sublog" / "weekly snapshot" wording avoids the reserved term "window" (ER only).
+// Daily-first framing, faithful to the pipeline: the daily DF counts are the PRIMARY extracted
+// artifact (one series per edge), and each week's DFG is their Σ-aggregate — not a weekly
+// sublog extracted first. Avoid the reserved term "window" (ER only).
 const STEPS = [
-  '① Event log → weekly sublog',
-  '② Each week → a time-indexed DFG',
-  '③ Each DF edge → a univariate time series',
-  '④ Forecast next week → forecasted DFG',
+  '① Event log → daily DF counts',
+  '② A week\'s DFG = Σ of 7 daily counts',
+  '③ Each DF edge → a daily time series',
+  '④ Forecast 7 days → sum → next week\'s DFG arc',
 ]
 
 // Event-log slice motif (per render_diagram.js buildLog). The log is tiled into one column-
@@ -64,35 +66,55 @@ const weekLabel = computed(() =>
   (dfgData.frames[props.frame].label.split(' · ')[1] || 'week').replace(' (forecast)', ''),
 )
 
-// Hero-edge sparkline geometry (per render_diagram.js buildSpark). Frame-independent scales;
-// the data-centred y-range shows the gentle weekly wiggle without faking a dramatic drift.
+// Hero-edge sparkline geometry (per render_diagram.js buildSpark). The figure is faithful to
+// the paper's temporal pipeline: each DF edge is a DAILY series, the forecast is 7 daily steps,
+// and those 7 sum (Σ) into the next week's DFG arc. So the x-axis is days — one 7-day group per
+// frame — not weeks. Frame-independent scales; the data-centred y-range shows the gentle daily
+// wiggle without faking a dramatic drift.
+const DAYS_PER_WEEK = 7
 const SPARK = (() => {
   const dims = { W: 200, H: 140, padL: 26, padR: 12, padT: 16, padB: 24 }
-  const vals = dfgData.frames.map((f) => f.weights[dfgData.hero])
+  // Flatten the per-frame daily series into one continuous daily timeline.
+  const vals = dfgData.frames.flatMap((f) => f.dailyHero)
   const { X, Y } = sparkScale(vals, dims)
-  return { ...dims, vals, X, Y, n: dfgData.frames.length }
+  // Day index at the centre of each frame's 7-day group — anchors the t₁..t₄ week ticks.
+  const weekTicks = dfgData.frames.map((_, w) => w * DAYS_PER_WEEK + Math.floor(DAYS_PER_WEEK / 2))
+  return { ...dims, vals, X, Y, n: dfgData.frames.length, weekTicks }
 })()
 
-// Accumulating sparkline state for the current frame: observed polyline (forecast point is
-// NOT on it), the dashed forecast segment (last frame only), dots, and the value readout.
+// Accumulating sparkline state for the current frame: each frame reveals its week's 7 daily
+// points. Observed days feed the solid line (the 7 forecast days are NOT on it); the forecast
+// frame lands them as a dashed accent tail of exactly 7 points, and the Σ readout shows those
+// 7 daily forecasts summing to the weekly forecast-DFG arc.
 const spark = computed(() => {
   const i = props.frame
-  const { vals, X, Y, n } = SPARK
+  const { vals, X, Y } = SPARK
   const obs = []
+  const forecast = []
   const dots = []
-  for (let k = 0; k <= i; k++) {
-    const isF = dfgData.frames[k].kind === 'forecast'
-    dots.push({ cx: X(k), cy: Y(vals[k]), isF })
-    if (!isF) obs.push(`${X(k)},${Y(vals[k])}`)
+  for (let w = 0; w <= i; w++) {
+    const isF = dfgData.frames[w].kind === 'forecast'
+    for (let d = 0; d < DAYS_PER_WEEK; d++) {
+      const k = w * DAYS_PER_WEEK + d
+      const pt = `${X(k)},${Y(vals[k])}`
+      dots.push({ cx: X(k), cy: Y(vals[k]), isF })
+      ;(isF ? forecast : obs).push(pt)
+    }
   }
-  const isLastForecast = i === n - 1 && dfgData.frames[i].kind === 'forecast'
-  const forecastPoints = isLastForecast
-    ? `${X(i - 1)},${Y(vals[i - 1])} ${X(i)},${Y(vals[i])}`
+  const isForecastFrame = dfgData.frames[i].kind === 'forecast'
+  const sumLabel = isForecastFrame
+    ? (() => {
+        const total = dfgData.frames[i].dailyHero.reduce((a, b) => a + b, 0)
+        const last = (i + 1) * DAYS_PER_WEEK - 1
+        return { x: X(last) - 2, y: Y(vals[last]) - 8, fill: dfgData.accent, text: `Σ ≈ ${total}` }
+      })()
     : null
-  const valLabel = isLastForecast
-    ? { x: X(i) - 2, y: Y(vals[i]) - 6, anchor: 'end', fill: dfgData.accent, text: `≈${vals[i]}` }
-    : { x: X(i) + 5, y: Y(vals[i]) - 5, anchor: 'start', fill: '#475569', text: `${vals[i]}` }
-  return { obsPoints: obs.join(' '), forecastPoints, dots, valLabel }
+  return {
+    obsPoints: obs.join(' '),
+    forecastPoints: forecast.length ? forecast.join(' ') : null,
+    dots,
+    sumLabel,
+  }
 })
 </script>
 
@@ -203,10 +225,11 @@ const spark = computed(() => {
 
       <!-- ③ per-edge time series -->
       <div class="wcol wcol-spark">
-        <div class="spark-title">O_Sent → O_Cancelled, per week</div>
+        <div class="spark-title">O_Sent → O_Cancelled, per day</div>
         <div class="slot slot-spark">
-    <!-- Accumulating hero-edge sparkline: observed line grows one point per frame; the
-         held-out forecast lands as a dashed accent segment on the final frame. -->
+    <!-- Accumulating hero-edge daily sparkline: each frame reveals its week's 7 daily points;
+         the 7-day forecast horizon lands as a dashed accent tail, summing (Σ) to the weekly
+         forecast-DFG arc on the final frame. -->
     <svg
       data-testid="sparkline" :viewBox="`0 0 ${SPARK.W} ${SPARK.H}`"
       width="100%" height="100%" preserveAspectRatio="xMidYMin meet"
@@ -219,9 +242,11 @@ const spark = computed(() => {
         :x1="SPARK.padL" :y1="SPARK.padT" :x2="SPARK.padL" :y2="SPARK.H - SPARK.padB"
         stroke="#cbd5e1" stroke-width="1"
       />
+      <!-- One week tick per frame, centred under its 7-day group — the bridge to the weekly DFG. -->
       <text
         v-for="(f, k) in dfgData.frames" :key="k"
-        :x="SPARK.X(k)" :y="SPARK.H - 6" text-anchor="middle" style="font-size: 8px" fill="#94a3b8"
+        :x="SPARK.X(SPARK.weekTicks[k])" :y="SPARK.H - 6" text-anchor="middle"
+        style="font-size: 8px" fill="#94a3b8"
       >t{{ k + 1 }}</text>
       <polyline
         data-testid="spark-line" fill="none" stroke="#0f172a" stroke-width="2"
@@ -230,17 +255,20 @@ const spark = computed(() => {
       <polyline
         v-if="spark.forecastPoints" data-testid="spark-forecast" fill="none"
         :stroke="dfgData.accent" stroke-width="2" stroke-dasharray="4 3"
-        stroke-linecap="round" :points="spark.forecastPoints"
+        stroke-linejoin="round" stroke-linecap="round" :points="spark.forecastPoints"
       />
+      <!-- Small per-day dots keep the line reading as a daily series; forecast days in accent. -->
       <circle
         v-for="(d, k) in spark.dots" :key="k" data-testid="spark-point"
-        :cx="d.cx" :cy="d.cy" :r="d.isF ? 3.2 : 3"
+        :cx="d.cx" :cy="d.cy" :r="d.isF ? 1.5 : 1.1"
         :fill="d.isF ? dfgData.accent : '#0f172a'"
       />
+      <!-- Σ readout: the 7 daily forecasts summing to the weekly forecast-DFG arc (≈316). -->
       <text
-        :x="spark.valLabel.x" :y="spark.valLabel.y" :text-anchor="spark.valLabel.anchor"
-        style="font-size: 9px" font-weight="700" :fill="spark.valLabel.fill"
-      >{{ spark.valLabel.text }}</text>
+        v-if="spark.sumLabel" data-testid="spark-sum"
+        :x="spark.sumLabel.x" :y="spark.sumLabel.y" text-anchor="end"
+        style="font-size: 10px" font-weight="700" :fill="spark.sumLabel.fill"
+      >{{ spark.sumLabel.text }}</text>
     </svg>
         </div>
         <div data-testid="step-3" class="cap cap-left">{{ STEPS[2] }}</div>

--- a/slides/template/components/dfgData.js
+++ b/slides/template/components/dfgData.js
@@ -37,6 +37,9 @@ export const dfgData = {
         sent__cancelled: 346, sent__returned: 477, returned__accepted: 394,
         accepted__end: 465, cancelled__end: 483,
       },
+      // Daily hero (sent__cancelled) series for this week; sums to weights.sent__cancelled
+      // (the paper bins daily and sums the horizon into the weekly DFG arc).
+      dailyHero: [48, 50, 49, 51, 47, 52, 49],
     },
     {
       label: 't₂ · Oct 09',
@@ -47,6 +50,7 @@ export const dfgData = {
         sent__cancelled: 314, sent__returned: 475, returned__accepted: 412,
         accepted__end: 353, cancelled__end: 412,
       },
+      dailyHero: [46, 44, 45, 43, 47, 45, 44],
     },
     {
       label: 't₃ · Oct 16',
@@ -57,6 +61,7 @@ export const dfgData = {
         sent__cancelled: 316, sent__returned: 436, returned__accepted: 382,
         accepted__end: 306, cancelled__end: 435,
       },
+      dailyHero: [45, 46, 44, 47, 45, 44, 45],
     },
     {
       label: 't₄ · Oct 23 (forecast)',
@@ -67,6 +72,8 @@ export const dfgData = {
         sent__cancelled: 316, sent__returned: 436, returned__accepted: 382,
         accepted__end: 306, cancelled__end: 435,
       },
+      // 7 daily forecast steps (prediction_length: 7); their Σ is the weekly forecast-DFG arc.
+      dailyHero: [46, 45, 45, 44, 46, 45, 45],
       truth: {
         start__create: 903, create__created: 903, created__sent: 823,
         sent__cancelled: 315, sent__returned: 497, returned__accepted: 343,

--- a/slides/template/components/dfgData.test.js
+++ b/slides/template/components/dfgData.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { dfgData } from './dfgData.js'
+
+describe('dfgData — daily hero series rollup invariant', () => {
+  // The paper bins DF relations daily and sums the 7 daily forecasts per edge into one
+  // weekly forecast-DFG (src/pmf_tsfm/er/dfg.py:247 window_pred.sum(axis=0)). So each frame's
+  // 7 daily hero values must roll up to that frame's weekly DFG weight.
+  it('gives every frame a 7-day hero series', () => {
+    for (const frame of dfgData.frames) {
+      expect(frame.dailyHero).toHaveLength(7)
+    }
+  })
+
+  it('sums each frame\'s daily hero series to its weekly DFG weight', () => {
+    for (const frame of dfgData.frames) {
+      const sum = frame.dailyHero.reduce((a, b) => a + b, 0)
+      expect(sum).toBe(frame.weights[dfgData.hero])
+    }
+  })
+})


### PR DESCRIPTION
Closes #84.

Makes the slide-3 `DfgEvolution` figure faithful to the paper's temporal pipeline — the **daily** DF time series is the primary extracted artifact, the model forecasts **7 daily steps**, and those are **summed per edge** into the weekly forecast-DFG arc (`er/dfg.py:247` `window_pred.sum(axis=0)`).

## Right panel (issue #84)
- Hero-edge sparkline is now a **daily** series: each weekly click reveals that week's 7 daily points; the forecast click adds a **7-point dashed accent tail** (the horizon).
- A **Σ ≈ 316** readout shows the rollup matching the DFG arc (`≈316`, truth 315) — teaches the sum-over-horizon with no cross-column arrow.
- Per-frame `dailyHero` arrays **sum to the weekly DFG weight** (346/314/316/316), enforced by a new unit-tested rollup invariant.

## Faithful pipeline reframe
The left→middle captions implied *weekly-first extraction*, inverting the real dependency. Re-cast so daily is primary and the weekly DFG reads as its Σ-aggregate:
- ① `Event log → daily DF counts`
- ② `A week's DFG = Σ of 7 daily counts`

The locked `talk_design/outline.md` Beat 2 workflow line is updated to the faithful daily-first chain to match (a deliberate, discussed revision).

## Unchanged
Left log-slice + middle DFG layout, monochrome + single KU Leuven accent.

## Verification
- `pnpm test` → **28 passed** (incl. rollup invariant, daily sparkline shape, Σ readout, caption-semantics guard).
- `pnpm build` → clean.
- `slidev export --range 3 --with-clicks` reviewed: daily line, 7-point dashed forecast tail, `Σ ≈ 316`, captions ①–④.