### PR TITLE
feat(demo): deploy bundled GPU-free explorer to an HF Space (#113)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,67 @@
+name: Deploy demo to HF Space
+
+# Sync the bundled forecast explorer to its Hugging Face Gradio-SDK Space (PRD #112, slice 1 #113).
+# Only the gradio-only serve-time subset of demo/ is published, so the Space needs no graphviz
+# binary and no GPU (ADR-0005). Precompute-time code, tests, and handoff notes stay out of the Space.
+#
+# One-time setup (HITL): create the Space, set the `HF_TOKEN` repo secret (write-scoped), and set the
+# `HF_SPACE_ID` repo variable (e.g. "YongboYu/pmf-forecasting-explorer").
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "demo/**"
+      - ".github/workflows/deploy-demo.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Hugging Face Hub client
+        run: pip install --upgrade "huggingface_hub>=0.25"
+
+      - name: Stage the serve-time subset
+        # Explicit allow-list: only what the running app reads. Anything not copied here never
+        # reaches the Space, keeping the runtime gradio-only.
+        run: |
+          set -euo pipefail
+          rm -rf _space && mkdir -p _space
+          cp demo/app.py demo/forecast.py demo/requirements.txt demo/README.md _space/
+          cp -r demo/static demo/assets _space/
+          echo "Staged for the Space:"
+          find _space -maxdepth 2 -type f | sort
+
+      - name: Push to the HF Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_id = os.environ["HF_SPACE_ID"]
+          api.upload_folder(
+              folder_path="_space",
+              repo_id=space_id,
+              repo_type="space",
+              commit_message=f"Sync demo from {os.environ.get('GITHUB_SHA', 'main')[:8]}",
+              # Purge anything on the Space that is no longer in the staged subset.
+              delete_patterns="*",
+          )
+          print(f"Deployed to https://huggingface.co/spaces/{space_id}")
+          PY

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,44 @@
+---
+title: Process Model Forecasting Explorer
+emoji: 🔮
+colorFrom: indigo
+colorTo: green
+sdk: gradio
+sdk_version: 6.16.0
+app_file: app.py
+pinned: false
+license: mit
+short_description: Explore TSFM forecasts of directly-follows process behaviour
+---
+
+# Process Model Forecasting — bundled explorer
+
+A GPU-free explorer for the CAiSE 2026 paper *Process Model Forecasting with Time Series Foundation
+Models* (arXiv:2512.07624). It makes the paper's result tangible: off-the-shelf Time-Series
+Foundation Models (Chronos-2, Moirai-2.0, TimesFM-2.5) can forecast how the **directly-follows (DF)
+relations** of a process evolve over time.
+
+## What you can do
+
+Pick one of the four bundled event logs (`bpi2017`, `bpi2019_1`, `sepsis`, `hospital_billing`) and a
+model. You see:
+
+- the **forecast DFG** (predicted next week of process behaviour) beside the **actual-future DFG**
+  (what really happened) — the bundled path is a *holdout backtest*: the real last week is held out
+  and forecast from the rest, so genuine ground truth exists;
+- a **Side-by-side / Diff** toggle, with the Diff view offering **Absolute** (forecast | actual
+  counts) and **Relative** (signed change %) labelling;
+- an **ER / MAE / RMSE** accuracy strip, with the truth-DFG ER baseline for context.
+
+## How it runs
+
+Everything is served from **precomputed, committed assets** — including the pre-rendered SVG figures
+— so the app is instant, infinitely concurrent, needs **no GPU and no graphviz binary**, and cannot
+be DoS'd into a bill. The live custom-upload path (on ZeroGPU) and the REST/MCP surfaces are later
+slices of the same app.
+
+Run it locally:
+
+```bash
+uv run --with gradio python app.py
+```

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,0 +1,6 @@
+# Serve-time dependencies for the bundled forecast explorer HF Space.
+# Gradio-only by design (ADR-0005): the app serves precomputed assets incl. pre-rendered SVGs,
+# so the runtime needs no graphviz `dot` binary and no GPU. Precompute-time deps (graphviz,
+# pmf_tsfm, numpy, pandas) must never appear here — they belong to demo/precompute_demo.py only.
+# Pin matches the README frontmatter `sdk_version`.
+gradio==6.16.0

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -12,6 +12,8 @@ These tests pin the *serve-time* contract the Hugging Face Space relies on:
 
 from __future__ import annotations
 
+import ast
+import importlib.util
 import re
 import subprocess
 import sys
@@ -79,14 +81,13 @@ def test_readme_has_valid_hf_space_frontmatter():
     )
 
 
-def test_serve_path_imports_without_precompute_deps():
-    # In a fresh interpreter with only demo/ on the path (no src/), importing the serve path
-    # (app → forecast) must succeed and must NOT have pulled in the precompute-time modules.
-    # Run in a subprocess so the in-process suite (which imports render/precompute_demo) can't
-    # pollute the module table. This guards ADR-0005 against a stray `import render` at serve time.
+def _assert_clean_serve_import(import_stmt: str) -> None:
+    # In a fresh interpreter with only demo/ on the path (no src/), importing the serve path must
+    # succeed and must NOT have pulled in the precompute-time modules. Run in a subprocess so the
+    # in-process suite (which imports render/precompute_demo) can't pollute the module table.
     code = (
         f"import sys; sys.path.insert(0, {str(DEMO)!r}); "
-        "import app, forecast; "
+        f"{import_stmt}; "
         "bad = [m for m in ('render', 'precompute_demo', 'graphviz', 'pmf_tsfm') "
         "if m in sys.modules]; "
         "assert not bad, bad"
@@ -95,6 +96,16 @@ def test_serve_path_imports_without_precompute_deps():
         [sys.executable, "-c", code], capture_output=True, text=True
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_serve_path_imports_without_precompute_deps():
+    # forecast.py is the gradio-free serve core — always checkable, incl. in CI (no gradio there).
+    # This guards ADR-0005 against a stray `import render` (which would drag in graphviz).
+    _assert_clean_serve_import("import forecast")
+    # app.py is the other half of the serve path but imports gradio; only check it where gradio
+    # is installed (locally / on the Space), matching the demo suite's gradio-optional convention.
+    if importlib.util.find_spec("gradio") is not None:
+        _assert_clean_serve_import("import app, forecast")
 
 
 # The serve artifacts every bundled dataset x model combo must ship (ADR-0002/0005).
@@ -109,12 +120,37 @@ _ASSET_FILES = (
 )
 
 
+def _app_string_list(name: str) -> list[str]:
+    """Read a module-level ``name: list[str] = [...]`` literal from app.py without importing it.
+
+    Importing app.py would pull in gradio, which is absent in CI; the dropdown choices are plain
+    string literals, so we lift them straight from the source instead.
+    """
+    tree = ast.parse((DEMO / "app.py").read_text())
+    for node in tree.body:
+        target = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target = node.target.id
+        elif (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            target = node.targets[0].id
+        if target == name and isinstance(node.value, (ast.List, ast.Tuple)):
+            return [el.value for el in node.value.elts if isinstance(el, ast.Constant)]
+    raise AssertionError(f"{name} list literal not found in app.py")
+
+
 def test_every_offered_combo_has_committed_assets():
-    import app  # the dropdown choices are the source of truth for what must be served
+    # The dropdown choices are the source of truth for what must be served.
+    datasets = _app_string_list("DATASETS")
+    models = _app_string_list("MODELS")
+    assert datasets and models, "could not read DATASETS/MODELS from app.py"
 
     missing = []
-    for dataset in app.DATASETS:
-        for model in app.MODELS:
+    for dataset in datasets:
+        for model in models:
             for fname in _ASSET_FILES:
                 path = DEMO / "assets" / dataset / model / fname
                 if not path.is_file():

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -1,0 +1,135 @@
+"""Deployment contract for the bundled forecast explorer's HF Space (slice 1, #113).
+
+These tests pin the *serve-time* contract the Hugging Face Space relies on:
+
+  - ``requirements.txt`` lists **gradio only** — no graphviz / pmf_tsfm / numpy / pandas
+    (ADR-0005: serve-time deps stay gradio-only so the Space needs no ``dot`` binary and no GPU).
+  - ``README.md`` carries valid HF Space YAML frontmatter (so HF builds the Space at all).
+  - importing the serve path (``forecast`` / ``app``) never pulls the precompute-time modules.
+  - every offered dataset x model combo has its committed assets (the Space serves files, ADR-0002).
+  - the deploy workflow syncs only the serve-time subset of ``demo/`` to the Space.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+DEMO = Path(__file__).resolve().parent.parent
+REPO = DEMO.parent
+WORKFLOW = REPO / ".github" / "workflows" / "deploy-demo.yml"
+
+# Heavy / precompute-time deps that must never reach the gradio-only serve runtime (ADR-0005).
+_FORBIDDEN_SERVE_DEPS = ("graphviz", "pmf-tsfm", "pmf_tsfm", "numpy", "pandas", "torch")
+
+
+def _requirement_names(text: str) -> set[str]:
+    """The bare package names in a requirements.txt, lower-cased, stripped of version specifiers."""
+    names = set()
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        name = re.split(r"[<>=!~ \[]", line, maxsplit=1)[0].strip().lower()
+        if name:
+            names.add(name)
+    return names
+
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Parse a leading ``---``-delimited YAML block of flat ``key: value`` pairs."""
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not m:
+        return {}
+    out = {}
+    for line in m.group(1).splitlines():
+        if ":" in line and not line.lstrip().startswith("#"):
+            key, _, val = line.partition(":")
+            out[key.strip()] = val.strip()
+    return out
+
+
+def test_requirements_pins_gradio_and_nothing_heavy():
+    names = _requirement_names((DEMO / "requirements.txt").read_text())
+    assert "gradio" in names
+    assert not (names & set(_FORBIDDEN_SERVE_DEPS)), (
+        f"requirements.txt must stay gradio-only (ADR-0005); found {names & set(_FORBIDDEN_SERVE_DEPS)}"
+    )
+
+
+def test_readme_has_valid_hf_space_frontmatter():
+    fm = _frontmatter((DEMO / "README.md").read_text())
+    assert fm.get("sdk") == "gradio", "HF Space must be a Gradio-SDK Space (ADR-0003 amended)"
+    assert fm.get("app_file") == "app.py", "app_file must point at the Space-root app.py"
+    assert "sdk_version" in fm, "HF needs a pinned sdk_version to build the Space"
+    # The pinned Space SDK version must agree with the serve-time requirements pin.
+    req = (DEMO / "requirements.txt").read_text()
+    pin = next(
+        (
+            line.split("==", 1)[1].strip()
+            for line in req.splitlines()
+            if line.strip().lower().startswith("gradio==")
+        ),
+        None,
+    )
+    assert fm["sdk_version"] == pin, (
+        f"README sdk_version ({fm['sdk_version']}) must match requirements.txt gradio pin ({pin})"
+    )
+
+
+def test_serve_path_imports_without_precompute_deps():
+    # In a fresh interpreter with only demo/ on the path (no src/), importing the serve path
+    # (app → forecast) must succeed and must NOT have pulled in the precompute-time modules.
+    # Run in a subprocess so the in-process suite (which imports render/precompute_demo) can't
+    # pollute the module table. This guards ADR-0005 against a stray `import render` at serve time.
+    code = (
+        f"import sys; sys.path.insert(0, {str(DEMO)!r}); "
+        "import app, forecast; "
+        "bad = [m for m in ('render', 'precompute_demo', 'graphviz', 'pmf_tsfm') "
+        "if m in sys.modules]; "
+        "assert not bad, bad"
+    )
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted constant code
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+# The serve artifacts every bundled dataset x model combo must ship (ADR-0002/0005).
+_ASSET_FILES = (
+    "forecast_dfg.json",
+    "actual_dfg.json",
+    "metrics.json",
+    "forecast.svg",
+    "actual.svg",
+    "diff_absolute.svg",
+    "diff_relative.svg",
+)
+
+
+def test_every_offered_combo_has_committed_assets():
+    import app  # the dropdown choices are the source of truth for what must be served
+
+    missing = []
+    for dataset in app.DATASETS:
+        for model in app.MODELS:
+            for fname in _ASSET_FILES:
+                path = DEMO / "assets" / dataset / model / fname
+                if not path.is_file():
+                    missing.append(str(path.relative_to(DEMO)))
+    assert not missing, f"offered combos missing committed assets: {missing}"
+
+
+def test_deploy_workflow_syncs_only_the_serve_time_subset():
+    text = WORKFLOW.read_text()
+    # Triggered by demo/ changes on main, authenticated with the HF token secret.
+    assert "branches:" in text and "main" in text
+    assert "demo/" in text, "workflow should be path-filtered to demo/ changes"
+    assert "HF_TOKEN" in text, "workflow must auth to the Space with the HF_TOKEN secret"
+    # The gradio-only Space must never receive precompute-time modules (ADR-0005).
+    for forbidden in ("precompute_demo.py", "render.py"):
+        assert forbidden not in text, (
+            f"deploy workflow must not sync {forbidden} to the Space (keep it gradio-only)"
+        )

--- a/docs/adr/0003-multi-surface-single-app-delivery.md
+++ b/docs/adr/0003-multi-surface-single-app-delivery.md
@@ -1,4 +1,9 @@
-# One Gradio app delivers GUI + REST + MCP; packaged as a single self-hostable GUI+CLI image
+# One Gradio app delivers GUI + REST + MCP; one codebase, two packagings
+
+> **Amended (PRD #112, HF-deployment grilling).** The original decision called the hosted Space, the
+> talk-recording build, and the self-host image the *identical* Docker artifact. That is softened to
+> **"one codebase, two packagings"** — see the Amendment section below. The "one Gradio app, three
+> surfaces (GUI + REST + MCP)" core stands unchanged.
 
 We want the work usable by humans, scripts, *and* modern agents without building and maintaining
 separate services. A Gradio app launched with `mcp_server=True` simultaneously exposes a **GUI**, an
@@ -23,3 +28,21 @@ and a tool others self-host on their own logs/hardware (no caps). A Claude **Ski
   accuracy metrics (ER/MAE/RMSE) are a **GUI-only** reproducibility concern. `mcp_server=True` is
   flipped on only *after* the GUI tracer-bullet slice — building the GUI does **not** block on the
   MCP contract, as long as the forecast functions are written agent-clean from the start.
+
+## Amendment — one codebase, two packagings (PRD #112)
+
+The "*identical* Docker artifact for Space + talk + self-host" turned out to over-constrain the
+hosted path. The **HF Space is a Gradio-SDK Space** (`app.py` + `requirements.txt` at the Space root,
+serve-time deps gradio-only per ADR-0005) — *not* a hand-built Docker image. That is the simplest
+gradio-only host **and** the native home for ZeroGPU (ADR-0001), which the live-upload slice needs;
+ZeroGPU is far more fragile on Docker-SDK Spaces.
+
+So the same `demo/` codebase ships as **two packagings**, not one:
+
+1. the **Gradio-SDK HF Space** — the hosted runtime (GUI now; REST/MCP via `mcp_server=True`; ZeroGPU
+   for the live path);
+2. a **self-host Docker image** (GUI default entrypoint + Hydra CLI) — built from the same code for
+   talk-recording and others self-hosting with no caps. **Future work**, not built in PRD #112.
+
+"One codebase, every surface" holds; "one *identical artifact*" does not. The CLI / PyPI / Claude
+Skill remain the recorded destination and remain future work.


### PR DESCRIPTION
Slice 1 of the HF-deployment stage (PRD #112, closes #113).

Packages the existing bundled forecast explorer for a **Hugging Face Gradio-SDK Space** and auto-syncs it from `main`. No app behaviour changes — only deployment config + tests + an ADR amendment.

## What's here
- **`demo/requirements.txt`** — gradio-only serve deps. The serve path (`app → forecast`) needs no graphviz `dot` and no GPU (ADR-0005).
- **`demo/README.md`** — HF Space YAML frontmatter (`sdk: gradio`, `sdk_version: 6.16.0`, `app_file: app.py`) + blurb.
- **`.github/workflows/deploy-demo.yml`** — on push to `main` touching `demo/`, stage only the serve-time subset (`app.py`, `forecast.py`, `static/`, `assets/`, `requirements.txt`, `README.md`) and upload to the Space (`delete_patterns="*"` purges stale files). Auth via `HF_TOKEN` secret + `HF_SPACE_ID` variable.
- **`demo/tests/test_deploy.py`** — 5 deploy-contract tests (TDD): gradio-only requirements, valid HF frontmatter, serve path imports without precompute deps, every offered combo has committed assets, workflow syncs only the serve-time subset.
- **`docs/adr/0003`** — amended to **"one codebase, two packagings"**: a Gradio-SDK Space (hosted runtime) + a future self-host Docker image, instead of one identical artifact. Decided during the deployment grilling because ZeroGPU (slice 3, ADR-0001) is far better supported on Gradio-SDK Spaces.

## Quality gate
`44 passed` (39 existing + 5 new), `ruff check`/`format` clean, workflow YAML valid.

## Required one-time setup before/at merge (maintainer)
1. Create a **Gradio-SDK** HF Space (CPU basic, public).
2. Repo **secret** `HF_TOKEN` (write-scoped) + repo **variable** `HF_SPACE_ID` (e.g. `owner/pmf-forecasting-explorer`).
3. Merging this PR pushes to `main` → triggers `deploy-demo` → first deploy. (If the secret/variable aren't set yet, re-run the job after setting them.)

Carry-forward: #91 (precompute input-contract docs) is adopted into PRD #112 and is non-blocking here (assets are already committed).
