### PR TITLE
feat(demo): live forecast core — forecast_live + upload guard + drift (#114)

### DIFF
--- a/demo/forecast_live.py
+++ b/demo/forecast_live.py
@@ -1,0 +1,134 @@
+"""Assemble a live-path forecast for a custom-uploaded log.
+
+The sibling of :func:`forecast.forecast_bundled`, for the *live* path (ADR-0004):
+the forecast origin is the **log end**, so it forecasts the genuine, unseen next
+window and compares it against the **last-known-window** DFG. There is no future
+truth for an upload, so this path reports **drift** (DF relations the forecast
+adds/removes vs the recent past) and **never** an accuracy metric (ER/MAE/RMSE).
+
+The public :func:`forecast_live` is agent-clean (typed args + docstring, no Gradio
+objects) — its signature is the future MCP/REST tool schema. The actual
+preprocessing + model inference sits behind :func:`_live_windows`, which is wired
+to ZeroGPU in a follow-up slice (#115); the assembly, guard, and drift logic here
+are GPU-free and tested in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import upload_guard
+from dfg_diff import dfg_diff
+from precompute_demo import frequencies_to_dfg_json
+from render import dfg_json_to_svg, diff_svg
+
+
+def _live_windows(
+    log: str | Path, model: str, horizon: int
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Preprocess + forecast one upload, the GPU seam wired to ZeroGPU in #115.
+
+    Returns ``(forecast_window, last_known_window, feature_names)`` where both windows
+    are ``(horizon, n_features)`` DF-relation frequency arrays in the **same** feature
+    space (so the two DFGs key consistently): the forecast for the next ``horizon`` days
+    from the log end, and the actual last ``horizon`` days of the log. #115 implements
+    this (preprocess log → DF-relation series; model.predict → forecast window; series
+    tail → last-known window); the tests monkeypatch it.
+    """
+    raise NotImplementedError(
+        "live preprocessing + inference is wired on ZeroGPU in #115; tests monkeypatch this seam"
+    )
+
+
+def drift_report(
+    forecast_dfg: dict[str, Any], comparison_dfg: dict[str, Any]
+) -> dict[str, list[dict[str, Any]]]:
+    """Partition DF relations as **drift** of the forecast vs the last-known window.
+
+    Reuses :func:`dfg_diff.dfg_diff` but reframes it relative to the recent past
+    (not an accuracy comparison): ``dfg_diff(forecast, comparison)`` calls a relation
+    present only in the forecast ``removed`` and one present only in the comparison
+    ``added`` — the *opposite* of the drift reading — so the two are swapped here.
+
+    Args:
+        forecast_dfg:   The forecast DFG (``{"nodes": [...], "arcs": [...]}``).
+        comparison_dfg: The last-known-window DFG, same shape.
+
+    Returns:
+        ``{"added": [...], "removed": [...], "stable": [...]}`` where ``added`` are
+        relations the forecast introduces vs the recent past, ``removed`` are ones it
+        drops, and ``stable`` are common to both. Each entry is
+        ``{"from": label, "to": label, "forecast_freq": int, "recent_freq": int}`` —
+        the ``recent_freq`` (not ``actual_freq``) naming keeps this off the accuracy
+        framing: there is no future truth to score against (ADR-0004).
+    """
+    diff = dfg_diff(forecast_dfg, comparison_dfg)
+
+    def entry(e: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "from": e["from"],
+            "to": e["to"],
+            "forecast_freq": e["forecast_freq"],
+            "recent_freq": e["actual_freq"],
+        }
+
+    return {
+        "added": [entry(e) for e in diff["removed"]],  # in forecast, not in recent past
+        "removed": [entry(e) for e in diff["added"]],  # in recent past, not in forecast
+        "stable": [entry(e) for e in diff["matched"]],
+    }
+
+
+def forecast_live(
+    log: str | Path,
+    model: str = "chronos2",
+    horizon: int = 7,
+) -> dict[str, Any]:
+    """Forecast a custom-uploaded log's true future and report its drift.
+
+    The live path (ADR-0004): the forecast origin is the log end, so the forecast is
+    the genuine unseen next ``horizon`` days, compared against the **last-known-window**
+    DFG. There is no future truth for an upload, so the bundle carries **drift** (DF
+    relations the forecast adds/removes vs the recent past) and **never** an accuracy
+    metric (no ER/MAE/RMSE). This is the function the MCP/REST tool exposes.
+
+    Args:
+        log:     Path to the uploaded XES log.
+        model:   TSFM id (default ``"chronos2"``; ``moirai2``/``timesfm2.5`` are gated to
+                 small logs by the upload guard).
+        horizon: Forecast horizon in days. Fixed at 7 in v1.
+
+    Returns:
+        ``{"forecast_dfg": <dfg json>, "comparison_dfg": <dfg json>,
+           "drift": {"added": [...], "removed": [...], "stable": [...]},
+           "forecast_svg": str, "comparison_svg": str,
+           "diff_absolute_svg": str, "diff_relative_svg": str}`` — the JSON DFGs (the
+        regenerable source of truth) alongside pre-rendered figures. The ``comparison_*``
+        is the last-known-window DFG (not actual future), and the bundle reports drift,
+        never accuracy.
+
+    Raises:
+        UploadRejected: the log is too large or the model is gated for its size.
+
+    Note:
+        The reused ``diff_svg`` legend still reads "forecast | actual" / "over/under-forecast
+        %"; relabelling the live diff view ("last-known window" / "% change from recent
+        past") is a GUI concern handled when the live path is wired (#115). The bundle
+        *data* already uses the correct drift vocabulary and carries no accuracy metric.
+    """
+    model = upload_guard.check_upload(log, model)
+    forecast_window, last_known_window, feature_names = _live_windows(log, model, horizon)
+
+    forecast_dfg = frequencies_to_dfg_json(forecast_window, feature_names)
+    comparison_dfg = frequencies_to_dfg_json(last_known_window, feature_names)
+    return {
+        "forecast_dfg": forecast_dfg,
+        "comparison_dfg": comparison_dfg,
+        "drift": drift_report(forecast_dfg, comparison_dfg),
+        "forecast_svg": dfg_json_to_svg(forecast_dfg),
+        "comparison_svg": dfg_json_to_svg(comparison_dfg),
+        "diff_absolute_svg": diff_svg(forecast_dfg, comparison_dfg, mode="absolute"),
+        "diff_relative_svg": diff_svg(forecast_dfg, comparison_dfg, mode="relative"),
+    }

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -1,0 +1,235 @@
+"""Tests for the live-path forecast core (slice 3a, #114).
+
+The live path forecasts a custom upload's true future (forecast origin = log end)
+and compares it against the **last-known-window** DFG, so it reports **drift**
+(DF relations added/removed) and **never** accuracy (ADR-0004). These deep modules
+are gradio-free and tested through their public interfaces:
+
+upload_guard.py
+  - check_upload — size caps + model gating + default Chronos-2, clear rejections
+forecast_live.py
+  - drift_report  — DF relations partitioned as drift vs the recent past
+  - forecast_live — assembles the live bundle (drift, never accuracy) from a log
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from upload_guard import UploadRejected, check_upload
+
+
+def _dfg(*relations):
+    """Build a DFG JSON document from ``(from_label, to_label, freq)`` triples."""
+    labels = sorted({end for f, t, _ in relations for end in (f, t)})
+    ids = {label: i for i, label in enumerate(labels)}
+    return {
+        "nodes": [{"label": label, "id": i} for label, i in ids.items()],
+        "arcs": [{"from": ids[f], "to": ids[t], "freq": freq} for f, t, freq in relations],
+    }
+
+
+def _log_of_size(tmp_path, n_bytes: int):
+    """A throwaway file standing in for an uploaded XES log of a given byte size."""
+    path = tmp_path / "upload.xes"
+    path.write_bytes(b"x" * n_bytes)
+    return path
+
+
+def test_oversize_log_is_rejected(tmp_path, monkeypatch):
+    """A log past the hard byte cap is rejected with a clear message, not forecast."""
+    import upload_guard
+
+    monkeypatch.setattr(upload_guard, "MAX_UPLOAD_BYTES", 100)
+    log = _log_of_size(tmp_path, 200)
+    with pytest.raises(UploadRejected, match="cap"):
+        check_upload(log, "chronos2")
+
+
+def test_default_model_is_chronos2(tmp_path):
+    """With no model named, the guard selects the GPU-cheap default (Chronos-2)."""
+    log = _log_of_size(tmp_path, 10)
+    assert check_upload(log) == "chronos2"
+
+
+def test_unknown_model_is_rejected(tmp_path):
+    """An unrecognised model id is refused rather than passed through to the GPU."""
+    log = _log_of_size(tmp_path, 10)
+    with pytest.raises(UploadRejected, match="unknown model"):
+        check_upload(log, "gpt5")
+
+
+@pytest.mark.parametrize("gated", ["moirai2", "timesfm2.5"])
+def test_gated_model_rejected_on_large_log(tmp_path, monkeypatch, gated):
+    """Moirai/TimesFM are refused on a log over the small-log threshold (under the hard cap)."""
+    import upload_guard
+
+    monkeypatch.setattr(upload_guard, "SMALL_LOG_BYTES", 100)
+    log = _log_of_size(tmp_path, 200)
+    with pytest.raises(UploadRejected, match="small logs"):
+        check_upload(log, gated)
+
+
+def test_gated_model_allowed_on_small_log(tmp_path, monkeypatch):
+    """The same gated model is allowed when the log is under the small-log threshold."""
+    import upload_guard
+
+    monkeypatch.setattr(upload_guard, "SMALL_LOG_BYTES", 100)
+    log = _log_of_size(tmp_path, 50)
+    assert check_upload(log, "moirai2") == "moirai2"
+
+
+def test_default_model_unaffected_by_small_log_gate(tmp_path, monkeypatch):
+    """Chronos-2 stays available on a large (under-cap) log — only the heavy models are gated."""
+    import upload_guard
+
+    monkeypatch.setattr(upload_guard, "SMALL_LOG_BYTES", 100)
+    log = _log_of_size(tmp_path, 200)
+    assert check_upload(log, "chronos2") == "chronos2"
+
+
+# --- drift_report -----------------------------------------------------------
+
+
+def _rels(entries):
+    return {(e["from"], e["to"]) for e in entries}
+
+
+def test_drift_report_partitions_relative_to_recent_past():
+    """Drift is framed against the recent past: a relation only in the forecast is *added*
+    (the forecast introduces it); one only in the recent window is *removed* (the forecast
+    drops it); one in both is *stable*."""
+    from forecast_live import drift_report
+
+    forecast = _dfg(("A", "B", 5), ("A", "C", 3))  # A->C is new vs recent past
+    comparison = _dfg(("A", "B", 4), ("A", "D", 2))  # A->D existed recently, forecast drops it
+
+    drift = drift_report(forecast, comparison)
+
+    assert _rels(drift["added"]) == {("A", "C")}
+    assert _rels(drift["removed"]) == {("A", "D")}
+    assert _rels(drift["stable"]) == {("A", "B")}
+
+
+def test_drift_report_uses_recent_not_actual_vocabulary():
+    """Entries carry forecast vs *recent* weights — never the accuracy framing (actual/er/mae)."""
+    from forecast_live import drift_report
+
+    drift = drift_report(_dfg(("A", "B", 5)), _dfg(("A", "B", 4)))
+
+    stable = drift["stable"][0]
+    assert stable == {"from": "A", "to": "B", "forecast_freq": 5, "recent_freq": 4}
+    blob = repr(drift).lower()
+    assert (
+        "actual" not in blob
+        and "er" not in stable
+        and not (blob.count("mae") or blob.count("rmse"))
+    )
+
+
+# --- forecast_live ----------------------------------------------------------
+
+_LIVE_BUNDLE_KEYS = {
+    "forecast_dfg",
+    "comparison_dfg",
+    "drift",
+    "forecast_svg",
+    "comparison_svg",
+    "diff_absolute_svg",
+    "diff_relative_svg",
+}
+
+
+@pytest.fixture
+def stub_windows(monkeypatch):
+    """Replace the GPU seam with a fixed forecast / last-known window pair.
+
+    Forecast predicts A->B and A->C; the recent window held A->B and A->D — so the
+    drift is: A->C added, A->D removed, A->B stable.
+    """
+    import forecast_live
+
+    feature_names = ["A -> B", "A -> C", "A -> D"]
+    forecast_window = np.array([[3.0, 2.0, 0.0], [2.0, 1.0, 0.0]])  # A->B=5, A->C=3, A->D=0
+    last_known_window = np.array([[2.0, 0.0, 1.0], [2.0, 0.0, 1.0]])  # A->B=4, A->C=0, A->D=2
+    monkeypatch.setattr(
+        forecast_live,
+        "_live_windows",
+        lambda log, model, horizon: (forecast_window, last_known_window, feature_names),
+    )
+
+
+def test_forecast_live_returns_drift_bundle(tmp_path, stub_windows):
+    """forecast_live assembles the live bundle: twin DFGs + drift + pre-rendered SVGs."""
+    from forecast_live import forecast_live
+
+    log = _log_of_size(tmp_path, 10)
+    bundle = forecast_live(log, "chronos2", horizon=2)
+
+    assert set(bundle) == _LIVE_BUNDLE_KEYS
+    assert {"nodes", "arcs"} <= set(bundle["forecast_dfg"])
+    assert {"nodes", "arcs"} <= set(bundle["comparison_dfg"])
+    for key in ("forecast_svg", "comparison_svg", "diff_absolute_svg", "diff_relative_svg"):
+        assert "<svg" in bundle[key]
+
+
+def test_forecast_live_reports_drift_never_accuracy(tmp_path, stub_windows):
+    """The live bundle carries drift (added/removed) and **no** accuracy metric (ADR-0004)."""
+    from forecast_live import forecast_live
+
+    bundle = forecast_live(_log_of_size(tmp_path, 10), "chronos2", horizon=2)
+
+    assert "metrics" not in bundle
+    drift = bundle["drift"]
+    assert _rels(drift["added"]) == {("A", "C")}
+    assert _rels(drift["removed"]) == {("A", "D")}
+    blob = repr(bundle["drift"]).lower()
+    assert "er" not in bundle and "mae" not in blob and "rmse" not in blob
+
+
+def test_forecast_live_rejects_oversize_before_inference(tmp_path, monkeypatch):
+    """A guard rejection short-circuits: the GPU seam is never reached for a bad upload."""
+    import forecast_live
+
+    monkeypatch.setattr(forecast_live.upload_guard, "MAX_UPLOAD_BYTES", 100)
+
+    def _boom(*a, **k):  # the seam must not run when the guard rejects
+        raise AssertionError("_live_windows reached despite guard rejection")
+
+    monkeypatch.setattr(forecast_live, "_live_windows", _boom)
+    with pytest.raises(UploadRejected):
+        forecast_live.forecast_live(_log_of_size(tmp_path, 200), "chronos2")
+
+
+def test_forecast_live_signature_is_typed_and_documented():
+    """forecast_live's signature is the future MCP schema: every arg + return typed, documented."""
+    import inspect
+
+    from forecast_live import forecast_live
+
+    sig = inspect.signature(forecast_live)
+    assert all(p.annotation is not inspect.Parameter.empty for p in sig.parameters.values())
+    assert sig.return_annotation is not inspect.Signature.empty
+    assert (forecast_live.__doc__ or "").strip()
+
+
+def test_forecast_live_imports_no_gradio():
+    """The live core stays gradio-free, so flipping mcp_server=True derives a clean tool schema.
+
+    Checked in a fresh interpreter (like the serve-import test) so an in-process import of
+    app (which pulls gradio) can't pollute the result.
+    """
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    demo = Path(__file__).resolve().parent.parent
+    code = (
+        f"import sys; sys.path.insert(0, {str(demo)!r}); "
+        "import forecast_live; "
+        "assert 'gradio' not in sys.modules, 'forecast_live must not import gradio'"
+    )
+    result = subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted constant code
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr

--- a/demo/upload_guard.py
+++ b/demo/upload_guard.py
@@ -1,0 +1,57 @@
+"""Guard a custom-upload forecast before it ever reaches the GPU.
+
+The live path runs user-supplied XES logs on a serverless GPU with a hard
+wall-time cap (ADR-0001), so an upload is screened *up front*: logs past a byte
+cap are rejected, and the heavier model families are gated to small logs. The
+byte size is a cheap upfront proxy for runtime; a finer feature-count gate is a
+later (#115) concern. Rejections raise :class:`UploadRejected` with a clear,
+human-readable message so the GUI/agent can show *why*, not an opaque failure.
+
+This module is deliberately gradio-free and stdlib-only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MAX_UPLOAD_BYTES = 25 * 1024 * 1024  # hard cap: logs past this are rejected outright
+
+SMALL_LOG_BYTES = 5 * 1024 * 1024  # gate: the heavy models are offered only below this
+
+DEFAULT_MODEL = "chronos2"  # GPU-cheap default; the only model offered for large logs
+KNOWN_MODELS = {"chronos2", "moirai2", "timesfm2.5"}
+# Heavier families gated to small logs so a single call stays under the GPU wall-time cap.
+GATED_MODELS = {"moirai2", "timesfm2.5"}
+
+
+class UploadRejected(ValueError):  # noqa: N818 - domain name reads "upload rejected", not *Error
+    """An upload was refused by the guard (too large, or a gated model choice)."""
+
+
+def check_upload(log: str | Path, model: str = DEFAULT_MODEL) -> str:
+    """Screen an uploaded log + model choice before forecasting.
+
+    Args:
+        log:   Path to the uploaded XES log.
+        model: Requested TSFM id (e.g. ``"chronos2"``).
+
+    Returns:
+        The validated model id to forecast with.
+
+    Raises:
+        UploadRejected: the model is unknown, the log exceeds the hard size cap, or a
+            gated model (Moirai/TimesFM) was chosen for a log over the small-log threshold.
+    """
+    if model not in KNOWN_MODELS:
+        raise UploadRejected(f"unknown model {model!r}; choose one of {sorted(KNOWN_MODELS)}.")
+    size = Path(log).stat().st_size
+    if size > MAX_UPLOAD_BYTES:
+        raise UploadRejected(
+            f"log is {size / 1e6:.1f} MB; the upload cap is {MAX_UPLOAD_BYTES / 1e6:.1f} MB."
+        )
+    if model in GATED_MODELS and size > SMALL_LOG_BYTES:
+        raise UploadRejected(
+            f"{model} is only available for small logs (< {SMALL_LOG_BYTES / 1e6:.1f} MB); "
+            f"use {DEFAULT_MODEL} for this {size / 1e6:.1f} MB log."
+        )
+    return model


### PR DESCRIPTION
Closes #114 (PRD #112, slice 3a).

## What

The deterministic **core of the live (custom-upload) path** as gradio-free deep modules — **no GPU/Space/GUI wiring** (that is #115). Real TSFM inference is behind a single mocked seam.

- **`demo/upload_guard.py`** — `check_upload(log, model)`: hard byte cap, default Chronos-2, unknown-model rejection, Moirai/TimesFM gated to small logs; clear `UploadRejected` messages.
- **`demo/forecast_live.py`**
  - `forecast_live(log, model="chronos2", horizon=7)` — agent-clean (typed + docstring = future MCP schema, no Gradio), mirrors `forecast_bundled` but for the true-future upload path: `comparison_dfg` is the **last-known-window** DFG and the bundle reports **drift**, never accuracy (no ER/MAE/RMSE), per ADR-0004.
  - `drift_report` — reuses `dfg_diff` but reframes it relative to the recent past (forecast-only relations are `added`, recent-only are `removed`) and uses `recent_freq`, not `actual_freq`.
  - `_live_windows` — the inference seam (preprocessing + model), deferred to #115; tests monkeypatch it.

Lives in new modules so the gradio-only serve contract (`test_deploy.py`) stays intact; `forecast.py`/`app.py`/workflow/assets untouched.

## Tests

14 new tests in `demo/tests/test_forecast_live.py`: guard (oversize/gating/default/unknown), `drift_report` remap, `forecast_live` assembly, drift-never-accuracy, agent-clean + gradio-free.

- `uv run pytest demo/tests/` (CI parity, no gradio) → 51 passed, 7 skipped
- `uv run --with gradio pytest demo/tests/` → 58 passed
- `ruff check` + `ruff format --check` clean; serve-contract import guard still green.

## Review focus (code only — no UI this round)

1. **`drift_report` semantics** — the dfg_diff flip (forecast-only → `added`, recent-only → `removed`; `recent_freq`).
2. **Guard thresholds** — `MAX_UPLOAD_BYTES=25MB`, `SMALL_LOG_BYTES=5MB`, byte-based size proxy.
3. **Bundle naming** — `comparison_dfg` + `drift` for the future MCP/REST tool.
4. **`_live_windows` seam boundary** — defers all preprocessing + model to #115.

Known caveat left for #115: the reused `diff_svg` legend still reads "forecast | actual" / "over-forecast %"; relabelling the live diff view is a GUI concern (documented in the `forecast_live` docstring). The bundle *data* already uses correct drift vocabulary.