### PR TITLE
feat(demo): live ZeroGPU upload path — forecast_live seam + live GUI tab (#115)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,11 +1,14 @@
 name: Deploy demo to HF Space
 
-# Sync the bundled forecast explorer to its Hugging Face Gradio-SDK Space (PRD #112, slice 1 #113).
-# Only the gradio-only serve-time subset of demo/ is published, so the Space needs no graphviz
-# binary and no GPU (ADR-0005). Precompute-time code, tests, and handoff notes stay out of the Space.
+# Sync the Process Model Forecasting explorer to its Hugging Face Gradio-SDK Space (PRD #112).
+# Only the serve-time subset of demo/ is published. The bundled path stays GPU-free (precomputed
+# assets); the live path (slice 3b, #115) adds the lean, vendored modules it imports — render +
+# dfg_build + dfg_diff + log_to_series + upload_guard + forecast_live — plus packages.txt (the
+# graphviz `dot` binary). The precompute module stays OUT (it imports pmf_tsfm, absent on the
+# Space); tests and handoff notes stay out too.
 #
-# One-time setup (HITL): create the Space, set the `HF_TOKEN` repo secret (write-scoped), and set the
-# `HF_SPACE_ID` repo variable (e.g. "YongboYu/pmf-forecasting-explorer").
+# One-time setup (HITL): create the Space, set the `HF_TOKEN` repo secret (write-scoped), set the
+# `HF_SPACE_ID` repo variable, and upgrade the Space to ZeroGPU (PRO) hardware for the live tab.
 
 on:
   push:
@@ -34,11 +37,15 @@ jobs:
 
       - name: Stage the serve-time subset
         # Explicit allow-list: only what the running app reads. Anything not copied here never
-        # reaches the Space, keeping the runtime gradio-only.
+        # reaches the Space. The bundled path needs app + forecast + assets; the live path adds the
+        # vendored modules forecast_live imports (render, dfg_build, dfg_diff, log_to_series,
+        # upload_guard) + packages.txt. The precompute module is excluded (it imports pmf_tsfm).
         run: |
           set -euo pipefail
           rm -rf _space && mkdir -p _space
-          cp demo/app.py demo/forecast.py demo/requirements.txt demo/README.md _space/
+          cp demo/app.py demo/forecast.py demo/forecast_live.py demo/upload_guard.py \
+             demo/log_to_series.py demo/dfg_build.py demo/dfg_diff.py demo/render.py \
+             demo/requirements.txt demo/packages.txt demo/README.md _space/
           cp -r demo/static demo/assets _space/
           echo "Staged for the Space:"
           find _space -maxdepth 2 -type f | sort

--- a/demo/README.md
+++ b/demo/README.md
@@ -9,19 +9,20 @@ app_file: app.py
 pinned: false
 license: mit
 short_description: Explore TSFM forecasts of directly-follows process behaviour
+suggested_hardware: zero-a10g
 ---
 
-# Process Model Forecasting — bundled explorer
+# Process Model Forecasting Explorer
 
-A GPU-free explorer for the CAiSE 2026 paper *Process Model Forecasting with Time Series Foundation
-Models* (arXiv:2512.07624). It makes the paper's result tangible: off-the-shelf Time-Series
-Foundation Models (Chronos-2, Moirai-2.0, TimesFM-2.5) can forecast how the **directly-follows (DF)
-relations** of a process evolve over time.
+An explorer for the CAiSE 2026 paper *Process Model Forecasting with Time Series Foundation Models*
+(arXiv:2512.07624). It makes the paper's result tangible: off-the-shelf Time-Series Foundation Models
+(Chronos-2, Moirai-2.0, TimesFM-2.5) can forecast how the **directly-follows (DF) relations** of a
+process evolve over time.
 
 ## What you can do
 
-Pick one of the four bundled event logs (`bpi2017`, `bpi2019_1`, `sepsis`, `hospital_billing`) and a
-model. You see:
+**Bundled explorer.** Pick one of the four bundled event logs (`bpi2017`, `bpi2019_1`, `sepsis`,
+`hospital_billing`) and a model. You see:
 
 - the **forecast DFG** (predicted next week of process behaviour) beside the **actual-future DFG**
   (what really happened) — the bundled path is a *holdout backtest*: the real last week is held out
@@ -30,12 +31,19 @@ model. You see:
   counts) and **Relative** (signed change %) labelling;
 - an **ER / MAE / RMSE** accuracy strip, with the truth-DFG ER baseline for context.
 
+**Live upload (your log).** Upload a custom **XES** log and forecast its genuine next week (forecast
+origin = the log end) on **ZeroGPU**. Because an upload has no future ground truth, this tab reports
+**drift** — the DF relations the forecast adds or drops vs the **last-known window** — and **never**
+an accuracy metric (ADR-0004). Default **Chronos-2**; oversize logs and heavy models are capped so a
+call stays under the GPU time limit.
+
 ## How it runs
 
-Everything is served from **precomputed, committed assets** — including the pre-rendered SVG figures
-— so the app is instant, infinitely concurrent, needs **no GPU and no graphviz binary**, and cannot
-be DoS'd into a bill. The live custom-upload path (on ZeroGPU) and the REST/MCP surfaces are later
-slices of the same app.
+The **bundled** path is served from **precomputed, committed assets** (incl. pre-rendered SVGs) — so
+it is instant, infinitely concurrent, needs **no GPU**, and cannot be DoS'd into a bill. The **live**
+path runs preprocessing + a Chronos-2 forecast under `@spaces.GPU` on **ZeroGPU** and renders its
+DFGs at request time (so the Space carries graphviz + the model libs; see `packages.txt` /
+`requirements.txt`). The REST/MCP surface is a later slice of the same app.
 
 Run it locally:
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,14 +1,19 @@
-"""Gradio app — the bundled forecast explorer (demo slice 1).
+"""Gradio app — the bundled explorer (slice 1) + the live upload path (slice 3b).
 
-Thin glue over the deep module ``forecast.forecast_bundled``: a dataset/model
-picker drives twin panes (forecast DFG | actual-future DFG), with a
-``[Side-by-side | Diff]`` toggle that swaps them for one colour-coded diff
-overlay. An ER/MAE/RMSE metrics strip stays below in both views. The bundled
-path is a holdout backtest (ADR-0004), so the metrics are genuine accuracy.
+Two tabs over the two agent-clean deep modules:
 
-Served entirely from precomputed assets — including the pre-rendered SVG figures,
-so the app needs no ``dot`` binary at runtime — GPU-free. Launch plainly;
-``mcp_server`` stays off in this slice (ADR-0003).
+* **Bundled explorer** — ``forecast.forecast_bundled``: a dataset/model picker drives
+  twin panes (forecast DFG | actual-future DFG) with a ``[Side-by-side | Diff]`` toggle
+  and an ER/MAE/RMSE strip. A holdout backtest (ADR-0004), so the metrics are genuine
+  accuracy. Served entirely from precomputed assets (pre-rendered SVGs) — GPU-free.
+* **Live upload** — ``forecast_live.forecast_live``: upload a custom XES log, forecast
+  its genuine next week *on ZeroGPU*, and read the **drift** of that forecast vs the
+  **last-known window** (DF relations added/removed). No future truth for an upload, so
+  this path shows **drift, never accuracy** (ADR-0004). The live forecast renders DFGs
+  at request time, so this path needs the ``dot`` binary + the model libs (unlike the
+  GPU-free bundled path) — see ``requirements.txt`` / ``packages.txt``.
+
+``mcp_server`` stays off in this slice (flipped on in #116, ADR-0003).
 
     uv run --with gradio python demo/app.py
 """
@@ -21,10 +26,47 @@ from typing import Any
 
 import gradio as gr
 from forecast import forecast_bundled
+from forecast_live import forecast_live, warm_up
+from upload_guard import UploadRejected
 
 # Only the precomputed bundled pairs are offered as choices: the full 4-by-3 matrix.
 DATASETS: list[str] = ["bpi2017", "bpi2019_1", "sepsis", "hospital_billing"]
 MODELS: list[str] = ["chronos2", "moirai2", "timesfm2.5"]
+
+# The live path runs on ZeroGPU. Only Chronos-2 is wired this slice (#115); moirai2 /
+# timesfm2.5 stay gated (a follow-up), so the live picker offers Chronos-2 alone.
+LIVE_MODELS: list[str] = ["chronos2"]
+
+# ZeroGPU boundary: ``@spaces.GPU`` requests a GPU slice for the ~120s of the live call
+# (ADR-0001). ``spaces`` only exists on the HF Space, so off-Space (local / CI) we fall
+# back to a no-op decorator and the same code runs on CPU for the visual check.
+try:
+    import spaces
+
+    _gpu = spaces.GPU(duration=120)
+except ImportError:  # pragma: no cover - exercised only off-Space
+
+    def _gpu(fn):  # type: ignore[no-redef]
+        return fn
+else:  # pragma: no cover - exercised only on the Space
+    # On ZeroGPU, warm-load Chronos-2 on cuda at import (HF guidance), so each call's
+    # ~120s budget is spent on inference, not a cold download/load. Non-fatal: if the
+    # startup load fails the first request falls back to a lazy load.
+    try:
+        warm_up("cuda")
+    except Exception as err:  # never block app startup on a warm-up miss
+        print(f"Chronos-2 warm-up skipped ({err}); will lazy-load on first request.")
+
+
+@_gpu
+def _run_live(log_path: str, model: str) -> dict[str, Any]:
+    """Run the live forecast under the ZeroGPU slice — the GPU entry point.
+
+    A thin wrapper so the GPU boundary sits at the GUI layer; ``forecast_live`` stays
+    agent-clean (no ``spaces`` dependency) for the future MCP/REST tool (#116).
+    """
+    return forecast_live(log_path, model)
+
 
 # Vendored (not CDN) so the Hugging Face Space works fully offline / behind
 # restrictive networks. svg-pan-zoom v3.6.2 — https://github.com/bumbu/svg-pan-zoom
@@ -159,80 +201,188 @@ def load_diff(dataset: str, model: str) -> tuple[str, str]:
     return _render_diff(forecast_bundled(dataset, model))
 
 
+def _drift_summary(drift: dict[str, list[dict[str, Any]]]) -> str:
+    """One-line drift tally vs the last-known window — counts only, never accuracy."""
+    return (
+        "**Drift vs the last-known window** — "
+        f"{len(drift['added'])} relation(s) the forecast **adds**, "
+        f"{len(drift['removed'])} it **drops**, "
+        f"{len(drift['stable'])} unchanged. "
+        "_This is change from the recent past, not accuracy — an upload has no future "
+        "truth to score against (ADR-0004)._"
+    )
+
+
+# Blank panes + cleared summary, reused when an upload is rejected or absent.
+_LIVE_BLANK: tuple[str, str, str, str, str] = ("", "", "", "", "")
+
+
+def run_live(log_path: str | None, model: str) -> tuple[str, str, str, str, str, str]:
+    """Forecast an uploaded log and assemble the live-tab outputs.
+
+    Returns ``(status_md, forecast_html, comparison_html, diff_abs_html, diff_rel_html,
+    drift_summary_md)``. A guard rejection (oversize / gated model / too-short log) or any
+    other failure short-circuits to a clear status message with blank panes — the GPU is
+    only reached for an accepted upload.
+    """
+    if not log_path:
+        return ("⬆️ Upload an XES event log, then press **Forecast**.", *_LIVE_BLANK)
+    try:
+        result = _run_live(log_path, model)
+    except UploadRejected as rejected:
+        return (f"⚠️ Upload rejected: {rejected}", *_LIVE_BLANK)
+    except Exception as err:
+        return (f"⚠️ Could not forecast this log: {err}", *_LIVE_BLANK)
+    return (
+        "✅ Forecast complete — showing the genuine next week vs the last-known window.",
+        _scrollable(result["forecast_svg"]),
+        _scrollable(result["comparison_svg"]),
+        _scrollable(result["diff_absolute_svg"]),
+        _scrollable(result["diff_relative_svg"]),
+        _drift_summary(result["drift"]),
+    )
+
+
+def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
+    """The bundled-explorer tab (slice 1), unchanged but nested under a gr.Tab.
+
+    Returns the ``(fn, inputs, outputs)`` the caller wires to ``demo.load`` (so the
+    initial render happens once the Blocks context is open).
+    """
+    gr.Markdown(
+        "Holdout backtest (ADR-0004): the real last week is **held out** and forecast "
+        "from the rest, then compared against what actually happened — so ER / MAE / RMSE "
+        "are genuine accuracy."
+    )
+    with gr.Row():
+        dataset = gr.Dropdown(DATASETS, value=DATASETS[0], label="Dataset")
+        model = gr.Dropdown(MODELS, value=MODELS[0], label="Model")
+    view = gr.Radio(["Side-by-side", "Diff"], value="Side-by-side", label="View")
+    with gr.Row(visible=True) as twin_panes:
+        with gr.Column():
+            gr.Markdown("### Forecast — the held-out last week, predicted")
+            forecast_pane = gr.HTML(elem_classes=["dfg-pane"])
+        with gr.Column():
+            gr.Markdown("### Actual future — what really happened that week")
+            actual_pane = gr.HTML(elem_classes=["dfg-pane"])
+    with gr.Column(visible=False) as diff_overlay:
+        gr.Markdown("### Diff — forecast vs actual future")
+        diff_mode = gr.Radio(
+            ["Absolute", "Relative"],
+            value="Absolute",
+            label="Diff mode",
+            info="Absolute: forecast | actual. Relative: signed change %.",
+        )
+        with gr.Row(visible=True) as diff_abs_row:
+            diff_abs_pane = gr.HTML(elem_classes=["dfg-pane"])
+        with gr.Row(visible=False) as diff_rel_row:
+            diff_rel_pane = gr.HTML(elem_classes=["dfg-pane"])
+    with gr.Row():
+        er = gr.Textbox(label="ER — forecast", interactive=False)
+        truth_er = gr.Textbox(label="ER — truth (baseline)", interactive=False)
+        mae = gr.Textbox(label="MAE", interactive=False)
+        rmse = gr.Textbox(label="RMSE", interactive=False)
+
+    outputs = [forecast_pane, actual_pane, er, truth_er, mae, rmse]
+    inputs = [dataset, model]
+
+    def refresh(dataset: str, model: str) -> tuple[Any, ...]:
+        """Recompute every pane so every view stays in sync with the pickers."""
+        result = forecast_bundled(dataset, model)
+        return (*_render_panes(result), *_render_diff(result))
+
+    all_outputs = [*outputs, diff_abs_pane, diff_rel_pane]
+    for picker in inputs:
+        picker.change(refresh, inputs, all_outputs)
+
+    def set_view(view: str) -> tuple[Any, Any]:
+        is_diff = view == "Diff"
+        return gr.update(visible=not is_diff), gr.update(visible=is_diff)
+
+    view.change(set_view, view, [twin_panes, diff_overlay])
+
+    def set_diff_mode(mode: str) -> tuple[Any, Any]:
+        is_rel = mode == "Relative"
+        return gr.update(visible=not is_rel), gr.update(visible=is_rel)
+
+    diff_mode.change(set_diff_mode, diff_mode, [diff_abs_row, diff_rel_row])
+    return refresh, inputs, all_outputs
+
+
+def _build_live_tab() -> None:
+    """The live upload tab (slice 3b): upload → ZeroGPU forecast → drift view."""
+    gr.Markdown(
+        "Upload a custom **XES** log to forecast its genuine next week (forecast origin = "
+        "the log end) on ZeroGPU, then read the **drift** of that forecast vs the "
+        "**last-known window** — DF relations the forecast adds or drops. There is no "
+        "future truth for an upload, so this path shows **drift, never accuracy** "
+        "(ADR-0004).  Default **Chronos-2**; large logs and heavy models are capped so a "
+        "call stays under the GPU time limit."
+    )
+    with gr.Row():
+        upload = gr.File(label="XES event log", file_types=[".xes"], type="filepath")
+        live_model = gr.Dropdown(LIVE_MODELS, value=LIVE_MODELS[0], label="Model")
+        run = gr.Button("Forecast", variant="primary")
+    status = gr.Markdown("⬆️ Upload an XES event log, then press **Forecast**.")
+    view = gr.Radio(["Side-by-side", "Drift"], value="Side-by-side", label="View")
+    with gr.Row(visible=True) as twin_panes:
+        with gr.Column():
+            gr.Markdown("### Forecast — the genuine next week, predicted")
+            forecast_pane = gr.HTML(elem_classes=["dfg-pane"])
+        with gr.Column():
+            gr.Markdown("### Last-known window — the recent past it is compared against")
+            comparison_pane = gr.HTML(elem_classes=["dfg-pane"])
+    with gr.Column(visible=False) as drift_overlay:
+        gr.Markdown("### Drift — forecast vs the last-known window")
+        drift_mode = gr.Radio(
+            ["Absolute", "Relative"],
+            value="Absolute",
+            label="Drift view",
+            info="Absolute: forecast | last-known window. Relative: % change from recent past.",
+        )
+        with gr.Row(visible=True) as diff_abs_row:
+            diff_abs_pane = gr.HTML(elem_classes=["dfg-pane"])
+        with gr.Row(visible=False) as diff_rel_row:
+            diff_rel_pane = gr.HTML(elem_classes=["dfg-pane"])
+    drift_summary = gr.Markdown()
+
+    run.click(
+        run_live,
+        [upload, live_model],
+        [status, forecast_pane, comparison_pane, diff_abs_pane, diff_rel_pane, drift_summary],
+    )
+
+    def set_view(view: str) -> tuple[Any, Any]:
+        is_drift = view == "Drift"
+        return gr.update(visible=not is_drift), gr.update(visible=is_drift)
+
+    view.change(set_view, view, [twin_panes, drift_overlay])
+
+    def set_drift_mode(mode: str) -> tuple[Any, Any]:
+        is_rel = mode == "Relative"
+        return gr.update(visible=not is_rel), gr.update(visible=is_rel)
+
+    drift_mode.change(set_drift_mode, drift_mode, [diff_abs_row, diff_rel_row])
+
+
 def build() -> gr.Blocks:
     """Build the Gradio Blocks app (without launching it)."""
-    with gr.Blocks(title="Bundled forecast explorer") as demo:
+    with gr.Blocks(title="Process Model Forecasting explorer") as demo:
         gr.Markdown(
-            "# Bundled forecast explorer\n"
-            "Holdout backtest (ADR-0004): the real last week is **held out** and forecast "
-            "from the rest, then compared against what actually happened — so ER / MAE / RMSE "
-            "are genuine accuracy."
+            "# Process Model Forecasting explorer\n"
+            "Can off-the-shelf time-series foundation models forecast how a process's "
+            "directly-follows behaviour evolves? Explore the paper's **bundled** backtests, "
+            "or **upload your own log** for a live forecast of its next week."
         )
-        with gr.Row():
-            dataset = gr.Dropdown(DATASETS, value=DATASETS[0], label="Dataset")
-            model = gr.Dropdown(MODELS, value=MODELS[0], label="Model")
-        view = gr.Radio(
-            ["Side-by-side", "Diff"],
-            value="Side-by-side",
-            label="View",
-        )
-        with gr.Row(visible=True) as twin_panes:
-            with gr.Column():
-                gr.Markdown("### Forecast — the held-out last week, predicted")
-                forecast_pane = gr.HTML(elem_classes=["dfg-pane"])
-            with gr.Column():
-                gr.Markdown("### Actual future — what really happened that week")
-                actual_pane = gr.HTML(elem_classes=["dfg-pane"])
-        with gr.Column(visible=False) as diff_overlay:
-            gr.Markdown("### Diff — forecast vs actual future")
-            # A sub-mode inside the Diff view: same grey/amber/red lines either way,
-            # the radio only swaps which text rides each arc.
-            diff_mode = gr.Radio(
-                ["Absolute", "Relative"],
-                value="Absolute",
-                label="Diff mode",
-                info="Absolute: forecast | actual. Relative: signed change %.",
-            )
-            with gr.Row(visible=True) as diff_abs_row:
-                diff_abs_pane = gr.HTML(elem_classes=["dfg-pane"])
-            with gr.Row(visible=False) as diff_rel_row:
-                diff_rel_pane = gr.HTML(elem_classes=["dfg-pane"])
-        with gr.Row():
-            er = gr.Textbox(label="ER — forecast", interactive=False)
-            truth_er = gr.Textbox(label="ER — truth (baseline)", interactive=False)
-            mae = gr.Textbox(label="MAE", interactive=False)
-            rmse = gr.Textbox(label="RMSE", interactive=False)
+        with gr.Tabs():
+            with gr.Tab("Bundled explorer"):
+                load_target = _build_bundled_tab()
+            with gr.Tab("Live upload (your log)"):
+                _build_live_tab()
 
-        outputs = [forecast_pane, actual_pane, er, truth_er, mae, rmse]
-        inputs = [dataset, model]
-
-        def refresh(dataset: str, model: str) -> tuple[Any, ...]:
-            """Recompute every pane so every view stays in sync with the pickers.
-
-            Resolves the forecast once and fans it into all panes, so the two diff
-            sub-views and the side-by-side panes always show the same window.
-            """
-            result = forecast_bundled(dataset, model)
-            return (*_render_panes(result), *_render_diff(result))
-
-        all_outputs = [*outputs, diff_abs_pane, diff_rel_pane]
-        for picker in inputs:
-            picker.change(refresh, inputs, all_outputs)
+        # Render the bundled tab once on load (the live tab waits for an upload).
+        refresh, inputs, all_outputs = load_target
         demo.load(refresh, inputs, all_outputs)
-
-        def set_view(view: str) -> tuple[Any, Any]:
-            """Swap the twin panes for the diff overlay; metrics strip stays put."""
-            is_diff = view == "Diff"
-            return gr.update(visible=not is_diff), gr.update(visible=is_diff)
-
-        view.change(set_view, view, [twin_panes, diff_overlay])
-
-        def set_diff_mode(mode: str) -> tuple[Any, Any]:
-            """Within the Diff view, swap the absolute pane for the relative one."""
-            is_rel = mode == "Relative"
-            return gr.update(visible=not is_rel), gr.update(visible=is_rel)
-
-        diff_mode.change(set_diff_mode, diff_mode, [diff_abs_row, diff_rel_row])
 
     # Gradio 6 takes `head` at launch() (not the Blocks constructor); stash it on
     # the Blocks so callers (main, tests, drivers) pass the same inlined payload.

--- a/demo/dfg_build.py
+++ b/demo/dfg_build.py
@@ -1,0 +1,74 @@
+"""Pure DFG-JSON builders shared by the precompute and live paths.
+
+Both the bundled precompute (``precompute_demo``) and the live upload path
+(``forecast_live``) turn a window of DF-relation frequencies into the
+``{"nodes": [...], "arcs": [...]}`` JSON the renderer consumes. That builder used to
+live in ``precompute_demo`` and reused ``pmf_tsfm.er.dfg.dfg_to_json`` — but the live
+path must run in the lean Space serve env **without** ``pmf_tsfm`` (and its heavy
+model deps). So the two small, pure functions live here, depending only on numpy.
+
+``dfg_to_json`` is a faithful copy of ``pmf_tsfm.er.dfg.dfg_to_json`` (same node-id
+and frequency conventions), so the bundled assets it produces are byte-identical.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def dfg_to_json(dfg: dict[tuple[str, str], int]) -> dict[str, Any]:
+    """Serialise a ``{(source, target): freq}`` DFG to the JSON node/arc format.
+
+    Node IDs: ▶ = 0, ■ = 1, other activities in encounter order.
+    Node frequency = sum of incoming arc frequencies (or outgoing for ▶).
+
+    A faithful copy of ``pmf_tsfm.er.dfg.dfg_to_json`` (kept here so the live path
+    needs no ``pmf_tsfm`` at serve time); changes must stay in lock-step with it.
+    """
+    reverse_map: dict[str, int] = {"▶": 0, "■": 1}
+    node_freq: dict[str, int] = {"▶": 0, "■": 0}
+
+    for (src, tgt), freq in dfg.items():
+        for label in (src, tgt):
+            if label not in reverse_map:
+                reverse_map[label] = len(reverse_map)
+                node_freq[label] = 0
+        if src == "▶":
+            node_freq["▶"] += freq
+        else:
+            node_freq[tgt] += freq
+
+    arcs = [
+        {"from": reverse_map[src], "to": reverse_map[tgt], "freq": freq}
+        for (src, tgt), freq in dfg.items()
+    ]
+    nodes = [
+        {"label": label, "id": nid, "freq": node_freq.get(label, 0)}
+        for label, nid in reverse_map.items()
+    ]
+    return {"nodes": nodes, "arcs": arcs}
+
+
+def frequencies_to_dfg_json(window: np.ndarray, feature_names: list[str]) -> dict[str, Any]:
+    """Build a clean DFG JSON from one window's DF-relation frequencies.
+
+    Sums the horizon, rounds, drops zero-frequency relations, and keeps the raw
+    ▶/■ markers so ``dfg_to_json`` maps them to the canonical start/end nodes —
+    no duplicate Start/End nodes and no artificial freq-1 arcs.
+
+    Args:
+        window:        shape (horizon, n_features) — one forecast/actual window.
+        feature_names: ``"A -> B"`` column names aligned with the last axis.
+
+    Returns:
+        DFG in ``{"nodes": [...], "arcs": [...]}`` format.
+    """
+    freqs = np.clip(np.round(window.sum(axis=0)), 0, None).astype(int)
+    dfg: dict[tuple[str, str], int] = {}
+    for name, freq in zip(feature_names, freqs, strict=True):
+        if freq > 0:
+            src, tgt = name.split("->", 1)
+            dfg[(src.strip(), tgt.strip())] = int(freq)
+    return dfg_to_json(dfg)

--- a/demo/forecast_live.py
+++ b/demo/forecast_live.py
@@ -20,26 +20,126 @@ from typing import Any
 
 import numpy as np
 import upload_guard
+from dfg_build import frequencies_to_dfg_json
 from dfg_diff import dfg_diff
-from precompute_demo import frequencies_to_dfg_json
+from log_to_series import log_to_df_series
 from render import dfg_json_to_svg, diff_svg
+
+# Chronos-2 is the only model wired on the hosted live path this slice (#115);
+# moirai2 / timesfm2.5 stay a documented follow-up. The id matches
+# configs/model/chronos/chronos2.yaml. Loading an ``s3://`` checkpoint needs boto3.
+_CHRONOS2_MODEL_ID = "s3://autogluon/chronos-2/"
+_chronos2_pipeline: object | None = None  # module-level cache, loaded once per process
+
+
+def _load_chronos2(device: str | None = None) -> object:
+    """Load (and cache) the Chronos-2 pipeline. Imports torch/chronos lazily so the
+    live-core module stays importable — and testable — without the model libs.
+
+    Args:
+        device: the device to place the model on. ``None`` (the default, used by the
+            per-call path) auto-detects: real ``cuda`` inside a ``@spaces.GPU`` call,
+            else ``cpu``. :func:`warm_up` passes ``"cuda"`` explicitly so the startup
+            load targets the GPU even under ZeroGPU's module-level CUDA emulation, where
+            ``torch.cuda.is_available()`` is ``False``.
+    """
+    global _chronos2_pipeline
+    if _chronos2_pipeline is None:
+        import torch
+        from chronos import BaseChronosPipeline
+
+        if device is None:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        _chronos2_pipeline = BaseChronosPipeline.from_pretrained(
+            _CHRONOS2_MODEL_ID, device_map=device
+        )
+    return _chronos2_pipeline
+
+
+def warm_up(device: str = "cuda") -> None:
+    """Eagerly load Chronos-2 at startup so per-call GPU time is spent on inference only.
+
+    HF ZeroGPU guidance is to load models on ``cuda`` at **module level** (it emulates
+    CUDA outside ``@spaces.GPU`` so the placement is cheap), not lazily inside the GPU
+    function — otherwise the *first* request pays the cold model download/load out of its
+    ~120s ``duration`` budget and may time out. The Space calls this once at import (see
+    ``app.py``); off-Space it is simply never called, and the per-call path lazy-loads on
+    CPU instead.
+    """
+    _load_chronos2(device=device)
+
+
+def _chronos2_forecast(context: np.ndarray, horizon: int) -> np.ndarray:
+    """Forecast the next ``horizon`` days of every DF relation with Chronos-2.
+
+    A minimal port of ``pmf_tsfm.models.chronos.ChronosAdapter._predict_chronos2_batched``
+    (batch every feature into one ``predict_df`` call via a per-feature ``item_id``, take
+    the median) — kept here so the live path needs only chronos-forecasting + torch, not
+    the full ``pmf_tsfm`` dep tree. **This is the GPU work** (wrapped by ``@spaces.GPU`` in
+    the GUI) and is what tests monkeypatch.
+
+    Args:
+        context: ``(n_days, n_features)`` history — the whole log's daily DF series.
+        horizon: number of future days to forecast.
+
+    Returns:
+        ``(horizon, n_features)`` forecast frequencies (median).
+    """
+    import pandas as pd
+
+    pipeline = _load_chronos2()
+    n_features = context.shape[1]
+    rows = [
+        {"item_id": feat_idx, "timestamp": t, "target": float(value)}
+        for feat_idx in range(n_features)
+        for t, value in enumerate(context[:, feat_idx])
+    ]
+    pred_df = pipeline.predict_df(  # type: ignore[attr-defined]
+        pd.DataFrame(rows), prediction_length=horizon, quantile_levels=[0.1, 0.5, 0.9]
+    )
+    forecast = np.zeros((horizon, n_features))
+    for feat_idx in range(n_features):
+        feat = pred_df[pred_df["item_id"] == feat_idx]
+        forecast[:, feat_idx] = feat["predictions"].to_numpy()[:horizon]
+    return forecast
 
 
 def _live_windows(
     log: str | Path, model: str, horizon: int
 ) -> tuple[np.ndarray, np.ndarray, list[str]]:
-    """Preprocess + forecast one upload, the GPU seam wired to ZeroGPU in #115.
+    """Preprocess + forecast one upload — the GPU seam (ADR-0004, ZeroGPU in #115).
 
     Returns ``(forecast_window, last_known_window, feature_names)`` where both windows
     are ``(horizon, n_features)`` DF-relation frequency arrays in the **same** feature
-    space (so the two DFGs key consistently): the forecast for the next ``horizon`` days
-    from the log end, and the actual last ``horizon`` days of the log. #115 implements
-    this (preprocess log → DF-relation series; model.predict → forecast window; series
-    tail → last-known window); the tests monkeypatch it.
+    space (so the two DFGs key consistently): the model forecast for the next ``horizon``
+    days *from the log end* (the genuine unseen future), and the actual last ``horizon``
+    days of the log (the recent past the drift is measured against).
+
+    The whole daily series is the forecast context; its tail is the last-known window.
+    Tests monkeypatch ``log_to_df_series`` / ``_chronos2_forecast`` to keep real model
+    inference out of CI (as slice 3a kept this whole seam mocked).
+
+    Raises:
+        UploadRejected: the model is not wired on the hosted live path, or the log spans
+            too few days to forecast a ``horizon``-day window from history.
     """
-    raise NotImplementedError(
-        "live preprocessing + inference is wired on ZeroGPU in #115; tests monkeypatch this seam"
-    )
+    if model != "chronos2":
+        raise upload_guard.UploadRejected(
+            f"{model} is not yet available on the hosted live demo; use chronos2."
+        )
+
+    series = log_to_df_series(log)
+    feature_names = list(series.columns)
+    values = series.to_numpy(dtype=float)
+    if len(values) < horizon + 1:
+        raise upload_guard.UploadRejected(
+            f"the log spans only {len(values)} day(s); at least {horizon + 1} are needed to "
+            f"forecast a {horizon}-day window from prior history."
+        )
+
+    last_known_window = values[-horizon:]
+    forecast_window = _chronos2_forecast(values, horizon)
+    return forecast_window, last_known_window, feature_names
 
 
 def drift_report(
@@ -113,10 +213,10 @@ def forecast_live(
         UploadRejected: the log is too large or the model is gated for its size.
 
     Note:
-        The reused ``diff_svg`` legend still reads "forecast | actual" / "over/under-forecast
-        %"; relabelling the live diff view ("last-known window" / "% change from recent
-        past") is a GUI concern handled when the live path is wired (#115). The bundle
-        *data* already uses the correct drift vocabulary and carries no accuracy metric.
+        The diff SVGs are rendered with ``framing="drift"`` so their legend reads
+        "forecast | last-known window" / "% change from recent past" (never "actual" or
+        accuracy) — the relabel the bundle carries, so the same SVGs are honest whether
+        shown in the GUI or returned by the future MCP tool.
     """
     model = upload_guard.check_upload(log, model)
     forecast_window, last_known_window, feature_names = _live_windows(log, model, horizon)
@@ -129,6 +229,10 @@ def forecast_live(
         "drift": drift_report(forecast_dfg, comparison_dfg),
         "forecast_svg": dfg_json_to_svg(forecast_dfg),
         "comparison_svg": dfg_json_to_svg(comparison_dfg),
-        "diff_absolute_svg": diff_svg(forecast_dfg, comparison_dfg, mode="absolute"),
-        "diff_relative_svg": diff_svg(forecast_dfg, comparison_dfg, mode="relative"),
+        "diff_absolute_svg": diff_svg(
+            forecast_dfg, comparison_dfg, mode="absolute", framing="drift"
+        ),
+        "diff_relative_svg": diff_svg(
+            forecast_dfg, comparison_dfg, mode="relative", framing="drift"
+        ),
     }

--- a/demo/log_to_series.py
+++ b/demo/log_to_series.py
@@ -1,0 +1,111 @@
+"""Convert an uploaded XES log into the daily DF-relation frequency series.
+
+A faithful in-repo port of the external `pmf-benchmark`_ preprocessing
+(``preprocessing/{event_log_processor,df_generator,time_series_creator}.py``) that
+produced this repo's ``data/time_series/*.parquet``. h5↔parquet verification (#115)
+confirmed that pipeline is the producer of the repo's series, so this port
+reproduces the same representation the demo's TSFMs were applied to.
+
+The pipeline, per upstream:
+
+1. read the XES log (pm4py),
+2. ``filter_variants_by_coverage_percentage`` — drop ultra-rare variants (mild; a
+   no-op on normal logs),
+3. ``insert_artificial_start_end`` — add the ▶ / ■ events (the source of the
+   ``▶ -> X`` / ``X -> ■`` columns),
+4. extract every consecutive-event DF pair ``"a -> b"`` recording the **source
+   event's** timestamp,
+5. lay the counts on a daily ``date_range`` over the log's span, bucketing each pair
+   by its **source-event day**.
+
+**Deliberate deviation from upstream:** upstream also trims 10% of the timespan off
+*each* end before step 4. This converter **omits the end-trim** — the live path
+forecasts the genuine future *from the log end* (ADR-0004), so trimming the recent
+end would discard exactly the window the forecast is anchored on. Fidelity to the
+training preprocessing is not a correctness gate on the upload path (it reports
+**drift**, not accuracy); what matters is that the forecast and last-known windows
+share one feature space, which they do — both are columns of this one frame.
+
+Gradio-free and ``pmf_tsfm``-free (only ``pm4py`` / ``pandas`` / ``numpy``), so it
+runs in the lean live-path serve env.
+
+.. _pmf-benchmark: https://github.com/YongboYu/pmf-benchmark
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+CASE_KEY = "case:concept:name"
+ACT_KEY = "concept:name"
+TS_KEY = "time:timestamp"
+
+# Match pmf-benchmark's preprocessing_config.yaml (event_log.filter_percentage).
+DEFAULT_FILTER_COVERAGE = 0.0001
+
+
+def log_to_df_series(
+    log: str | Path, *, filter_coverage: float = DEFAULT_FILTER_COVERAGE
+) -> pd.DataFrame:
+    """Read an XES log and return its daily DF-relation frequency series.
+
+    Args:
+        log:             Path to the uploaded XES event log.
+        filter_coverage: Variant-coverage threshold for the rare-variant filter
+                         (upstream default ``0.0001``); pass ``0`` to skip filtering.
+
+    Returns:
+        A ``(days × DF-relations)`` frame: a daily ``DatetimeIndex`` over the log's
+        full span and one ``"a -> b"`` column per directly-follows relation (with the
+        artificial ▶ / ■ markers), each cell the count of that relation whose source
+        event fell on that day.
+    """
+    import pm4py
+
+    df = pm4py.read_xes(str(log))
+    return event_df_to_series(df, filter_coverage=filter_coverage)
+
+
+def event_df_to_series(
+    df: pd.DataFrame, *, filter_coverage: float = DEFAULT_FILTER_COVERAGE
+) -> pd.DataFrame:
+    """Daily DF-relation series from an already-loaded event-log DataFrame.
+
+    Split out from :func:`log_to_df_series` so the assembly is testable without an
+    XES round-trip. Expects the standard XES columns (``case:concept:name``,
+    ``concept:name``, ``time:timestamp``).
+    """
+    import pm4py
+
+    df = pm4py.format_dataframe(df, case_id=CASE_KEY, activity_key=ACT_KEY, timestamp_key=TS_KEY)
+    if filter_coverage:
+        df = pm4py.filter_variants_by_coverage_percentage(df, filter_coverage)
+    # Artificial ▶ / ■ events (timestamps ±1ms around each case's first/last event), so
+    # the ``▶ -> first`` / ``last -> ■`` relations exist and bucket on the right day.
+    df = pm4py.insert_artificial_start_end(df)
+
+    work = df[[CASE_KEY, ACT_KEY, TS_KEY]].copy()
+    work[TS_KEY] = pd.to_datetime(work[TS_KEY], utc=True)
+    work = work.sort_values([CASE_KEY, TS_KEY])
+
+    # Each event's directly-following successor within its case; the last event per
+    # case has none (NaN) and contributes no outgoing relation.
+    work["_next"] = work.groupby(CASE_KEY, sort=False)[ACT_KEY].shift(-1)
+    pairs = work.dropna(subset=["_next"]).copy()
+    pairs["_relation"] = pairs[ACT_KEY].astype(str) + " -> " + pairs["_next"].astype(str)
+    # Bucket by the SOURCE event's calendar day (upstream uses ``start_time``).
+    pairs["_day"] = pairs[TS_KEY].dt.tz_convert("UTC").dt.tz_localize(None).dt.normalize()
+
+    counts = pairs.groupby(["_day", "_relation"]).size().unstack(fill_value=0)
+
+    # Lay the counts on a contiguous daily index over the full (untrimmed) log span —
+    # the artificial events keep ▶/■ on the adjacent real-event days, so this spans
+    # exactly the log's active days.
+    span = work[TS_KEY].dt.tz_convert("UTC").dt.tz_localize(None).dt.normalize()
+    days = pd.date_range(span.min(), span.max(), freq="D")
+    series = counts.reindex(days, fill_value=0).astype(int)
+    series.index.name = "date"
+    series.columns.name = None
+    return series

--- a/demo/packages.txt
+++ b/demo/packages.txt
@@ -1,0 +1,1 @@
+graphviz

--- a/demo/precompute_demo.py
+++ b/demo/precompute_demo.py
@@ -24,16 +24,15 @@ from __future__ import annotations
 import json
 from functools import cache
 from pathlib import Path
-from typing import Any
 
 import numpy as np
 import pandas as pd
+from dfg_build import dfg_to_json, frequencies_to_dfg_json
 from render import dfg_json_to_svg, diff_svg
 
 from pmf_tsfm.er.automaton import compute_er
 from pmf_tsfm.er.dfg import (
     build_truth_dfg,
-    dfg_to_json,
     extract_sublog,
     extract_traces,
     load_event_log,
@@ -69,29 +68,6 @@ DATASET_DIRS: dict[str, str] = {
 BUNDLED: list[tuple[str, str]] = [
     (dataset, model) for dataset in DATASET_DIRS for model in MODEL_DIRS
 ]
-
-
-def frequencies_to_dfg_json(window: np.ndarray, feature_names: list[str]) -> dict[str, Any]:
-    """Build a clean DFG JSON from one window's DF-relation frequencies.
-
-    Sums the horizon, rounds, drops zero-frequency relations, and keeps the raw
-    ▶/■ markers so ``dfg_to_json`` maps them to the canonical start/end nodes —
-    no duplicate Start/End nodes and no artificial freq-1 arcs.
-
-    Args:
-        window:        shape (horizon, n_features) — one forecast/actual window.
-        feature_names: ``"A -> B"`` column names aligned with the last axis.
-
-    Returns:
-        DFG in ``{"nodes": [...], "arcs": [...]}`` format.
-    """
-    freqs = np.clip(np.round(window.sum(axis=0)), 0, None).astype(int)
-    dfg: dict[tuple[str, str], int] = {}
-    for name, freq in zip(feature_names, freqs, strict=True):
-        if freq > 0:
-            src, tgt = name.split("->", 1)
-            dfg[(src.strip(), tgt.strip())] = int(freq)
-    return dfg_to_json(dfg)
 
 
 def truth_er_from_sublog(sublog: pd.DataFrame) -> float:

--- a/demo/render.py
+++ b/demo/render.py
@@ -43,21 +43,56 @@ _OVER_COLOUR = "#e8590c"  # orange — forecast over-shot the actual (warm = too
 _UNDER_COLOUR = "#0c8599"  # teal — forecast under-shot the actual (cool = too little)
 _NEUTRAL_COLOUR = "#555555"  # 0% (exact) or — (undefined: actual = 0)
 
-# Embedded legend rows: (line-sample HTML, meaning). The sample is a short glyph
-# in that class's colour — a solid rule for matched, dashes for the changed
-# classes — so a first-time reader can map line colour/style to meaning. The
-# samples are padded to a similar visual width so the column stays aligned.
-_LEGEND_ROWS = [
-    (f'<FONT COLOR="{_MATCHED_COLOUR}">&#9472;&#9472;&#9472;&#9472;&#9472;</FONT>', "matched"),
-    (
-        f'<FONT COLOR="{_ADDED_COLOUR}">&#8211; &#8211; &#8211;</FONT>',
-        "happened &#8212; forecast missed it",
-    ),
-    (
-        f'<FONT COLOR="{_REMOVED_COLOUR}">&#8211; &#8211; &#8211;</FONT>',
-        "forecast predicted it &#8212; did not happen",
-    ),
-]
+# The diff colours partition arcs the same way in either framing — only what each
+# class *means in words* changes with the comparison's nature:
+#
+# * "accuracy" (bundled, ADR-0004): the comparison is the **actual future**, so a
+#   forecast-only arc is an over-prediction and an actual-only arc was missed.
+# * "drift" (live upload): the comparison is the **last-known window**, so there is no
+#   truth to be right or wrong about — a forecast-only arc is one the forecast
+#   *introduces* vs the recent past, an actual-only arc one it *drops*. Never accuracy.
+#
+# ``dfg_diff(forecast, comparison)`` keys "added" = comparison-only (amber) and
+# "removed" = forecast-only (red); the wording below follows that orientation.
+_FRAMINGS: dict[str, dict[str, str]] = {
+    "accuracy": {
+        "comparison": "actual",
+        "matched": "matched",
+        "added": "happened &#8212; forecast missed it",
+        "removed": "forecast predicted it &#8212; did not happen",
+        "relative_caption": "-forecast %",
+        "over": "over",
+        "under": "under",
+    },
+    "drift": {
+        "comparison": "last-known window",
+        "matched": "unchanged vs recent past",
+        "added": "in recent past, not the forecast",
+        "removed": "in the forecast, not recent past",
+        "relative_caption": " than recent past, %",
+        "over": "higher",
+        "under": "lower",
+    },
+}
+
+
+def _legend_rows(framing: str) -> list[tuple[str, str]]:
+    """Embedded legend rows ``(line-sample HTML, meaning)`` for a framing.
+
+    The sample is a short glyph in that class's colour — a solid rule for matched,
+    dashes for the changed classes — so a first-time reader can map line colour/style
+    to meaning. The samples are padded to a similar visual width so the column stays
+    aligned. The *meanings* are framing-specific (accuracy vs drift).
+    """
+    words = _FRAMINGS[framing]
+    return [
+        (
+            f'<FONT COLOR="{_MATCHED_COLOUR}">&#9472;&#9472;&#9472;&#9472;&#9472;</FONT>',
+            words["matched"],
+        ),
+        (f'<FONT COLOR="{_ADDED_COLOUR}">&#8211; &#8211; &#8211;</FONT>', words["added"]),
+        (f'<FONT COLOR="{_REMOVED_COLOUR}">&#8211; &#8211; &#8211;</FONT>', words["removed"]),
+    ]
 
 
 def _relerr_label(forecast_freq: int, actual_freq: int) -> tuple[str, str]:
@@ -117,26 +152,39 @@ def dfg_json_to_svg(dfg: dict[str, Any]) -> str:
 
 
 def diff_svg(
-    forecast_dfg: dict[str, Any], actual_dfg: dict[str, Any], mode: str = "absolute"
+    forecast_dfg: dict[str, Any],
+    actual_dfg: dict[str, Any],
+    mode: str = "absolute",
+    framing: str = "accuracy",
 ) -> str:
-    """Render the forecast/actual diff as one colour-coded overlay SVG.
+    """Render the forecast/comparison diff as one colour-coded overlay SVG.
 
     Arcs are partitioned by :func:`dfg_diff.dfg_diff` and drawn with the same line
-    styling in either mode:
+    styling regardless of ``mode``/``framing``:
 
     * **matched** — solid grey,
-    * **added** (it happened, the forecast missed it) — amber dashed,
-    * **removed** (the forecast predicted it, it did not happen) — red dashed.
+    * **added** (comparison-only) — amber dashed,
+    * **removed** (forecast-only) — red dashed.
 
     ``mode`` selects only what each arc's *text* shows:
 
-    * ``"absolute"`` — the raw ``forecast (blue) | actual (green)`` pair,
-    * ``"relative"`` — the bare signed change % (orange over / teal under).
+    * ``"absolute"`` — the raw ``forecast (blue) | comparison (green)`` pair,
+    * ``"relative"`` — the bare signed change % (warm up / cool down).
+
+    ``framing`` selects only the legend *wording*, so an upload is never read as
+    accuracy (ADR-0004):
+
+    * ``"accuracy"`` (bundled) — the comparison is the actual future: ``actual`` /
+      ``over/under-forecast %`` / "happened — forecast missed it".
+    * ``"drift"`` (live upload) — the comparison is the last-known window:
+      ``last-known window`` / ``% change from recent past`` / "in recent past, not
+      the forecast". No truth, no accuracy.
 
     Args:
         forecast_dfg: The forecast DFG (``{"nodes": [...], "arcs": [...]}``).
-        actual_dfg:   The actual-future DFG, same shape.
+        actual_dfg:   The comparison DFG (actual-future or last-known window), same shape.
         mode:         ``"absolute"`` (default) or ``"relative"``.
+        framing:      ``"accuracy"`` (default) or ``"drift"``.
 
     Returns:
         An ``<svg>`` document as a string.
@@ -178,40 +226,42 @@ def diff_svg(
                 **styling[diff_class],
             )
 
-    _add_legend(graph, mode)
+    _add_legend(graph, mode, framing)
     return graph.pipe(format="svg").decode("utf-8")
 
 
-def _add_legend(graph: graphviz.Digraph, mode: str = "absolute") -> None:
+def _add_legend(graph: graphviz.Digraph, mode: str = "absolute", framing: str = "accuracy") -> None:
     """Embed a compact key as a single HTML-table node in its own cluster.
 
     The table has two parts: an edge-label key explaining what the arc text means in
-    this ``mode`` (the forecast/actual number pair, or the over/under change %), and
-    one row per diff class pairing a line sample with its meaning. A single table
-    keeps the legend tight instead of sprawling.
+    this ``mode`` (the forecast/comparison number pair, or the signed change %), and
+    one row per diff class pairing a line sample with its meaning. Both the key and the
+    rows are ``framing``-specific (accuracy vs drift). A single table keeps the legend
+    tight instead of sprawling.
     """
+    words = _FRAMINGS[framing]
     # The edge-label key spans the full width on its own row, so it does not widen
     # the line-sample column and throw the grid off. It is mode-specific: the
     # absolute view explains the bicolour number pair, the relative view the % axis.
     if mode == "relative":
         label_key = (
             '<FONT COLOR="#555555">edge label: </FONT>'
-            f'<FONT COLOR="{_OVER_COLOUR}">over</FONT>'
+            f'<FONT COLOR="{_OVER_COLOUR}">{words["over"]}</FONT>'
             '<FONT COLOR="#555555"> / </FONT>'
-            f'<FONT COLOR="{_UNDER_COLOUR}">under</FONT>'
-            '<FONT COLOR="#555555">-forecast %</FONT>'
+            f'<FONT COLOR="{_UNDER_COLOUR}">{words["under"]}</FONT>'
+            f'<FONT COLOR="#555555">{words["relative_caption"]}</FONT>'
         )
     else:
         label_key = (
             '<FONT COLOR="#555555">edge numbers: </FONT>'
             f'<FONT COLOR="{_FORECAST_COLOUR}">forecast</FONT>'
             f'<FONT COLOR="{_SEP_COLOUR}">&#160;|&#160;</FONT>'
-            f'<FONT COLOR="{_ACTUAL_COLOUR}">actual</FONT>'
+            f'<FONT COLOR="{_ACTUAL_COLOUR}">{words["comparison"]}</FONT>'
         )
     # The three diff classes form an aligned 2-column grid: line sample | meaning.
     class_rows = "".join(
         f'<TR><TD ALIGN="LEFT">{sample}</TD><TD ALIGN="LEFT">{meaning}</TD></TR>'
-        for sample, meaning in _LEGEND_ROWS
+        for sample, meaning in _legend_rows(framing)
     )
     table = (
         '<<TABLE BORDER="0" CELLBORDER="0" CELLSPACING="3">'

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,6 +1,21 @@
-# Serve-time dependencies for the bundled forecast explorer HF Space.
-# Gradio-only by design (ADR-0005): the app serves precomputed assets incl. pre-rendered SVGs,
-# so the runtime needs no graphviz `dot` binary and no GPU. Precompute-time deps (graphviz,
-# pmf_tsfm, numpy, pandas) must never appear here — they belong to demo/precompute_demo.py only.
-# Pin matches the README frontmatter `sdk_version`.
+# Serve-time dependencies for the Process Model Forecasting explorer HF Space.
+#
+# Two tabs, two needs (ADR-0005, amended for slice 3b / #115):
+#   * Bundled explorer — serves precomputed assets incl. pre-rendered SVGs; needs only
+#     gradio. GPU-free, no `dot` binary required for that path.
+#   * Live upload — preprocesses + forecasts an uploaded log on ZeroGPU and renders its
+#     DFGs at request time, so it pulls in graphviz, the model libs (Chronos-2), and the
+#     `spaces` GPU shim. `pmf_tsfm` is deliberately NOT installed — the live path reuses
+#     only the lean, vendored demo modules (dfg_build / log_to_series / forecast_live).
+#
+# The gradio pin must match the README frontmatter `sdk_version`. graphviz also needs the
+# system `dot` binary — see packages.txt.
 gradio==6.16.0
+spaces>=0.30
+graphviz>=0.20
+numpy>=1.24
+pandas>=2.2.3
+pm4py>=2.7.12.4
+torch>=2.2
+chronos-forecasting>=1.4.0
+boto3>=1.28  # Chronos-2 loads from an s3:// checkpoint (configs/model/chronos/chronos2.yaml)

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -281,6 +281,32 @@ def test_diff_svg_embeds_legend():
     assert FORECAST_COLOUR in svg and ACTUAL_COLOUR in svg
 
 
+def test_diff_svg_defaults_to_accuracy_framing():
+    """The default framing is accuracy, so the bundled path's legend is untouched."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL)
+    assert "actual" in svg
+    assert "last-known window" not in svg
+
+
+def test_diff_svg_drift_framing_relabels_legend_off_accuracy():
+    """framing='drift' (the live upload) speaks of the last-known window and the recent
+    past — never 'actual' or forecast-accuracy wording (ADR-0004: an upload is not scored)."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL, framing="drift")
+    # graphviz serialises the hyphen in "last-known" as the &#45; entity; match either form.
+    assert "known window" in svg  # the comparison's true nature (last-known window)
+    assert "recent past" in svg  # the diff-class wording is drift-framed
+    # the accuracy vocabulary is gone
+    assert "actual" not in svg
+    assert "missed it" not in svg and "did not happen" not in svg
+
+
+def test_diff_svg_relative_drift_caption_is_change_from_recent_past():
+    """The relative drift view reads '% change from recent past', not over/under-forecast %."""
+    svg = diff_svg(DRIFT_FORECAST, DRIFT_ACTUAL, mode="relative", framing="drift")
+    assert "recent past" in svg
+    assert "forecast %" not in svg  # the accuracy caption "over/under-forecast %" is gone
+
+
 # A pair exercising every signed-relative-error row on one render. Signed error is
 # (forecast - actual) / actual, integer-rounded:
 #   X->Y matched over  : 745 / 558 -> +34%
@@ -738,7 +764,8 @@ def test_app_head_inlines_vendored_pan_zoom(asset_dir):
 
 
 def test_app_panes_carry_dfg_pane_class(asset_dir):
-    """All four SVG panes carry the `dfg-pane` class so JS can target them."""
+    """Every SVG pane carries the `dfg-pane` class so JS can target them — four on the
+    bundled tab and four on the live tab."""
     pytest.importorskip("gradio")
     import app
 
@@ -747,7 +774,9 @@ def test_app_panes_carry_dfg_pane_class(asset_dir):
         for c in app.build().blocks.values()
         if getattr(c, "elem_classes", None) and "dfg-pane" in c.elem_classes
     ]
-    assert len(panes) == 4  # forecast, actual-future, diff absolute, diff relative
+    # bundled: forecast, actual-future, diff abs, diff rel; live: forecast, last-known,
+    # drift abs, drift rel.
+    assert len(panes) == 8
 
 
 @pytest.fixture
@@ -788,3 +817,88 @@ def test_app_load_diff_produces_both_overlays(drift_asset_dir):
         assert "#9e9e9e" in diff_html and "#ffb300" in diff_html and "#e53935" in diff_html
     # The two panes are distinct documents (absolute vs relative).
     assert absolute_html != relative_html
+
+
+# ---------------------------------------------------------------------------
+# app.py — the live upload tab (slice 3b, #115). The GUI glue over forecast_live;
+# the ZeroGPU forecast itself is stubbed (real inference is post-merge, on hardware).
+# ---------------------------------------------------------------------------
+
+_LIVE_STUB_BUNDLE = {
+    "forecast_svg": "<svg>forecast</svg>",
+    "comparison_svg": "<svg>last-known</svg>",
+    "diff_absolute_svg": "<svg>diff-abs</svg>",
+    "diff_relative_svg": "<svg>diff-rel</svg>",
+    "drift": {
+        "added": [{"from": "A", "to": "C", "forecast_freq": 3, "recent_freq": 0}],
+        "removed": [{"from": "A", "to": "D", "forecast_freq": 0, "recent_freq": 2}],
+        "stable": [{"from": "A", "to": "B", "forecast_freq": 5, "recent_freq": 4}],
+    },
+}
+
+
+def test_app_builds_both_tabs():
+    """The app exposes the bundled explorer and the live upload tab side by side."""
+    gr = pytest.importorskip("gradio")
+    import app
+
+    tabs = [c for c in app.build().blocks.values() if isinstance(c, gr.Tab)]
+    labels = {t.label for t in tabs}
+    assert {"Bundled explorer", "Live upload (your log)"} <= labels
+
+
+def test_run_live_renders_panes_and_drift_on_success(monkeypatch):
+    """A successful upload yields the twin panes, both drift overlays, and a drift tally."""
+    pytest.importorskip("gradio")
+    import app
+
+    monkeypatch.setattr(app, "_run_live", lambda log_path, model: _LIVE_STUB_BUNDLE)
+    status, forecast, comparison, diff_abs, diff_rel, summary = app.run_live("up.xes", "chronos2")
+
+    assert "✅" in status
+    for html in (forecast, comparison, diff_abs, diff_rel):
+        assert "<svg" in html
+    # Drift, never accuracy: the tally counts added/dropped and disclaims accuracy.
+    assert "adds" in summary and "drops" in summary
+    assert "not accuracy" in summary.lower()
+    assert "mae" not in summary.lower() and "rmse" not in summary.lower()
+
+
+def test_run_live_surfaces_upload_rejection_with_blank_panes(monkeypatch):
+    """A guard rejection shows a clear message and leaves the panes blank (no stale graph)."""
+    pytest.importorskip("gradio")
+    import app
+    from upload_guard import UploadRejected
+
+    def _reject(log_path, model):
+        raise UploadRejected("log is 40.0 MB; the upload cap is 25.0 MB.")
+
+    monkeypatch.setattr(app, "_run_live", _reject)
+    status, *panes = app.run_live("big.xes", "chronos2")
+
+    assert "rejected" in status.lower() and "cap" in status
+    assert panes == ["", "", "", "", ""]
+
+
+def test_run_live_prompts_when_no_file_uploaded():
+    """Pressing Forecast with no upload prompts for a log rather than reaching the GPU."""
+    pytest.importorskip("gradio")
+    import app
+
+    status, *panes = app.run_live(None, "chronos2")
+    assert "Upload" in status
+    assert panes == ["", "", "", "", ""]
+
+
+def test_run_live_reports_unexpected_failure_without_crashing(monkeypatch):
+    """Any non-guard failure is surfaced as a message, not an uncaught exception."""
+    pytest.importorskip("gradio")
+    import app
+
+    def _boom(log_path, model):
+        raise RuntimeError("graphviz exploded")
+
+    monkeypatch.setattr(app, "_run_live", _boom)
+    status, *panes = app.run_live("up.xes", "chronos2")
+    assert "Could not forecast" in status
+    assert panes == ["", "", "", "", ""]

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -1,13 +1,20 @@
-"""Deployment contract for the bundled forecast explorer's HF Space (slice 1, #113).
+"""Deployment contract for the explorer's HF Space (slice 1 #113, slice 3b #115).
 
-These tests pin the *serve-time* contract the Hugging Face Space relies on:
+These tests pin the *serve-time* contract the Hugging Face Space relies on. ADR-0005 is
+**amended** for slice 3b: the bundled path is still served from precomputed assets and
+stays import-pure, but the live tab forecasts uploads on ZeroGPU and renders their DFGs
+at request time, so the Space now legitimately carries graphviz + the model libs. The
+one hard line that remains: the Space never installs **pmf_tsfm** (its heavy model/uni2ts
+tree) — the live path reuses only the lean, vendored demo modules.
 
-  - ``requirements.txt`` lists **gradio only** — no graphviz / pmf_tsfm / numpy / pandas
-    (ADR-0005: serve-time deps stay gradio-only so the Space needs no ``dot`` binary and no GPU).
-  - ``README.md`` carries valid HF Space YAML frontmatter (so HF builds the Space at all).
-  - importing the serve path (``forecast`` / ``app``) never pulls the precompute-time modules.
-  - every offered dataset x model combo has its committed assets (the Space serves files, ADR-0002).
-  - the deploy workflow syncs only the serve-time subset of ``demo/`` to the Space.
+  - ``requirements.txt`` pins gradio (matching the README) and carries the live-path deps,
+    but never ``pmf_tsfm``.
+  - ``README.md`` carries valid HF Space YAML frontmatter incl. ``suggested_hardware`` for ZeroGPU.
+  - ``import forecast`` (the bundled core) stays pure; ``import app`` may pull the live deps
+    (render/graphviz) but never ``pmf_tsfm`` or the precompute module.
+  - every offered bundled dataset x model combo has its committed assets (ADR-0002).
+  - the deploy workflow syncs the serve-time subset of ``demo/`` (incl. the live modules), but
+    not ``precompute_demo.py`` (it imports pmf_tsfm).
 """
 
 from __future__ import annotations
@@ -23,8 +30,11 @@ DEMO = Path(__file__).resolve().parent.parent
 REPO = DEMO.parent
 WORKFLOW = REPO / ".github" / "workflows" / "deploy-demo.yml"
 
-# Heavy / precompute-time deps that must never reach the gradio-only serve runtime (ADR-0005).
-_FORBIDDEN_SERVE_DEPS = ("graphviz", "pmf-tsfm", "pmf_tsfm", "numpy", "pandas", "torch")
+# The one dep that must never reach the Space: pmf_tsfm (its heavy model/uni2ts/wandb tree).
+# The live path reuses only the lean, vendored demo modules instead (ADR-0005 amended, #115).
+_FORBIDDEN_SERVE_DEPS = ("pmf-tsfm", "pmf_tsfm")
+# The live tab needs these at serve time (ZeroGPU forecast + request-time DFG rendering).
+_REQUIRED_LIVE_DEPS = ("spaces", "graphviz", "torch", "chronos-forecasting", "pm4py")
 
 
 def _requirement_names(text: str) -> set[str]:
@@ -53,11 +63,15 @@ def _frontmatter(text: str) -> dict[str, str]:
     return out
 
 
-def test_requirements_pins_gradio_and_nothing_heavy():
+def test_requirements_serve_both_paths_but_never_pmf_tsfm():
     names = _requirement_names((DEMO / "requirements.txt").read_text())
     assert "gradio" in names
+    # The live tab's serve deps are present...
+    missing = set(_REQUIRED_LIVE_DEPS) - names
+    assert not missing, f"requirements.txt is missing live-path serve deps: {missing}"
+    # ...but pmf_tsfm (the heavy tree) is never installed on the Space (ADR-0005 amended).
     assert not (names & set(_FORBIDDEN_SERVE_DEPS)), (
-        f"requirements.txt must stay gradio-only (ADR-0005); found {names & set(_FORBIDDEN_SERVE_DEPS)}"
+        f"requirements.txt must never carry pmf_tsfm; found {names & set(_FORBIDDEN_SERVE_DEPS)}"
     )
 
 
@@ -66,6 +80,10 @@ def test_readme_has_valid_hf_space_frontmatter():
     assert fm.get("sdk") == "gradio", "HF Space must be a Gradio-SDK Space (ADR-0003 amended)"
     assert fm.get("app_file") == "app.py", "app_file must point at the Space-root app.py"
     assert "sdk_version" in fm, "HF needs a pinned sdk_version to build the Space"
+    # The live tab runs on ZeroGPU — the Space must request that hardware (#115).
+    assert fm.get("suggested_hardware") == "zero-a10g", (
+        "README must request ZeroGPU hardware (suggested_hardware: zero-a10g) for the live tab"
+    )
     # The pinned Space SDK version must agree with the serve-time requirements pin.
     req = (DEMO / "requirements.txt").read_text()
     pin = next(
@@ -81,15 +99,14 @@ def test_readme_has_valid_hf_space_frontmatter():
     )
 
 
-def _assert_clean_serve_import(import_stmt: str) -> None:
+def _assert_serve_import_excludes(import_stmt: str, forbidden: tuple[str, ...]) -> None:
     # In a fresh interpreter with only demo/ on the path (no src/), importing the serve path must
-    # succeed and must NOT have pulled in the precompute-time modules. Run in a subprocess so the
+    # succeed and must NOT have pulled in any ``forbidden`` module. Run in a subprocess so the
     # in-process suite (which imports render/precompute_demo) can't pollute the module table.
     code = (
         f"import sys; sys.path.insert(0, {str(DEMO)!r}); "
         f"{import_stmt}; "
-        "bad = [m for m in ('render', 'precompute_demo', 'graphviz', 'pmf_tsfm') "
-        "if m in sys.modules]; "
+        f"bad = [m for m in {forbidden!r} if m in sys.modules]; "
         "assert not bad, bad"
     )
     result = subprocess.run(  # noqa: S603 - fixed argv, no shell, trusted constant code
@@ -98,14 +115,17 @@ def _assert_clean_serve_import(import_stmt: str) -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_serve_path_imports_without_precompute_deps():
-    # forecast.py is the gradio-free serve core — always checkable, incl. in CI (no gradio there).
-    # This guards ADR-0005 against a stray `import render` (which would drag in graphviz).
-    _assert_clean_serve_import("import forecast")
-    # app.py is the other half of the serve path but imports gradio; only check it where gradio
-    # is installed (locally / on the Space), matching the demo suite's gradio-optional convention.
+def test_serve_path_imports_stay_pmf_tsfm_free():
+    # The bundled core stays import-pure: `import forecast` must drag in none of the precompute /
+    # render / graphviz / pmf_tsfm machinery (it reads precomputed assets only). Checkable in CI.
+    _assert_serve_import_excludes(
+        "import forecast", ("render", "precompute_demo", "graphviz", "pmf_tsfm")
+    )
+    # app.py imports gradio (and, for the live tab, render/graphviz) — only checkable where gradio
+    # is installed. The amended invariant: the whole serve path still never pulls pmf_tsfm or the
+    # precompute module (the live path reuses the vendored demo modules instead).
     if importlib.util.find_spec("gradio") is not None:
-        _assert_clean_serve_import("import app, forecast")
+        _assert_serve_import_excludes("import app, forecast", ("precompute_demo", "pmf_tsfm"))
 
 
 # The serve artifacts every bundled dataset x model combo must ship (ADR-0002/0005).
@@ -158,14 +178,24 @@ def test_every_offered_combo_has_committed_assets():
     assert not missing, f"offered combos missing committed assets: {missing}"
 
 
-def test_deploy_workflow_syncs_only_the_serve_time_subset():
+def test_deploy_workflow_syncs_the_serve_time_subset():
     text = WORKFLOW.read_text()
     # Triggered by demo/ changes on main, authenticated with the HF token secret.
     assert "branches:" in text and "main" in text
     assert "demo/" in text, "workflow should be path-filtered to demo/ changes"
     assert "HF_TOKEN" in text, "workflow must auth to the Space with the HF_TOKEN secret"
-    # The gradio-only Space must never receive precompute-time modules (ADR-0005).
-    for forbidden in ("precompute_demo.py", "render.py"):
-        assert forbidden not in text, (
-            f"deploy workflow must not sync {forbidden} to the Space (keep it gradio-only)"
-        )
+    # The live tab's modules + apt packages must be staged for the Space (#115).
+    for required in (
+        "forecast_live.py",
+        "upload_guard.py",
+        "log_to_series.py",
+        "dfg_build.py",
+        "dfg_diff.py",
+        "render.py",
+        "packages.txt",
+    ):
+        assert required in text, f"deploy workflow must sync {required} for the live tab"
+    # precompute_demo.py imports pmf_tsfm, which the Space never installs — keep it out.
+    assert "precompute_demo.py" not in text, (
+        "deploy workflow must not sync precompute_demo.py (it imports pmf_tsfm)"
+    )

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -15,6 +15,7 @@ forecast_live.py
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
 from upload_guard import UploadRejected, check_upload
 
@@ -125,6 +126,95 @@ def test_drift_report_uses_recent_not_actual_vocabulary():
         and "er" not in stable
         and not (blob.count("mae") or blob.count("rmse"))
     )
+
+
+# --- _live_windows (the seam: preprocess + forecast) ------------------------
+
+
+@pytest.fixture
+def stub_live_seam(monkeypatch):
+    """Stand in for the two halves of the seam: the log→series converter and the
+    Chronos-2 call. A 5-day series over 3 relations; the forecast is a constant 9.0."""
+    import forecast_live
+
+    cols = ["▶ -> A", "A -> B", "B -> ■"]
+    frame = pd.DataFrame(
+        [[1, 2, 1], [1, 1, 1], [0, 3, 0], [2, 2, 2], [1, 0, 1]],
+        columns=cols,
+        index=pd.date_range("2020-01-01", periods=5),
+    )
+    monkeypatch.setattr(forecast_live, "log_to_df_series", lambda log, **k: frame)
+    monkeypatch.setattr(
+        forecast_live,
+        "_chronos2_forecast",
+        lambda context, horizon: np.full((horizon, context.shape[1]), 9.0),
+    )
+    return frame
+
+
+def test_live_windows_forecasts_from_end_and_tails_the_recent_window(tmp_path, stub_live_seam):
+    """Both windows are ``(horizon, F)`` in one feature space: the forecast from the log
+    end, and the actual last ``horizon`` days (the recent past)."""
+    from forecast_live import _live_windows
+
+    forecast_window, last_known_window, feature_names = _live_windows(
+        tmp_path / "x.xes", "chronos2", 2
+    )
+
+    assert feature_names == list(stub_live_seam.columns)
+    assert forecast_window.shape == (2, 3) and last_known_window.shape == (2, 3)
+    # last-known = the recent tail of the series; forecast = the model's true-future call.
+    np.testing.assert_array_equal(last_known_window, stub_live_seam.to_numpy()[-2:])
+    np.testing.assert_array_equal(forecast_window, np.full((2, 3), 9.0))
+
+
+def test_live_windows_rejects_log_with_too_little_history(tmp_path, monkeypatch):
+    """A log spanning fewer than ``horizon + 1`` days can't anchor the forecast — rejected."""
+    import forecast_live
+
+    frame = pd.DataFrame(
+        [[1, 1]], columns=["A -> B", "B -> ■"], index=pd.date_range("2020-01-01", periods=1)
+    )
+    monkeypatch.setattr(forecast_live, "log_to_df_series", lambda log, **k: frame)
+    with pytest.raises(UploadRejected, match="day"):
+        forecast_live._live_windows(tmp_path / "x.xes", "chronos2", 7)
+
+
+def test_warm_up_loads_the_model_on_the_given_device(monkeypatch):
+    """warm_up eagerly loads Chronos-2 on the requested device (HF ZeroGPU guidance:
+    load at module level on cuda, not lazily inside the GPU call)."""
+    import forecast_live
+
+    captured = {}
+    monkeypatch.setattr(
+        forecast_live, "_load_chronos2", lambda device=None: captured.update(device=device)
+    )
+    forecast_live.warm_up("cuda")
+    assert captured == {"device": "cuda"}
+
+
+def test_live_windows_rejects_unwired_model_before_preprocessing(tmp_path, monkeypatch):
+    """Only chronos2 is wired this slice; a gated model is rejected before any work runs."""
+    import forecast_live
+
+    def _boom(*a, **k):
+        raise AssertionError("preprocessing ran for an unwired model")
+
+    monkeypatch.setattr(forecast_live, "log_to_df_series", _boom)
+    with pytest.raises(UploadRejected, match="chronos2"):
+        forecast_live._live_windows(tmp_path / "x.xes", "moirai2", 7)
+
+
+def test_forecast_live_runs_through_the_real_seam(tmp_path, stub_live_seam):
+    """End-to-end through the *real* _live_windows (only the converter + model mocked):
+    the bundle assembles and still carries drift, never accuracy."""
+    from forecast_live import forecast_live
+
+    bundle = forecast_live(_log_of_size(tmp_path, 10), "chronos2", horizon=2)
+
+    assert set(bundle) == _LIVE_BUNDLE_KEYS
+    assert "metrics" not in bundle
+    assert "<svg" in bundle["forecast_svg"]
 
 
 # --- forecast_live ----------------------------------------------------------

--- a/demo/tests/test_log_to_series.py
+++ b/demo/tests/test_log_to_series.py
@@ -1,0 +1,94 @@
+"""Tests for the live-path log→daily-DF-series converter (slice 3b, #115).
+
+``log_to_series`` is the in-repo, faithful port of the external ``pmf-benchmark``
+preprocessing (``preprocessing/{event_log_processor,df_generator,time_series_creator}``)
+that produced this repo's ``data/time_series/*.parquet``. It turns an uploaded XES
+log into the daily ``(days × DF-relations)`` frequency frame the TSFM forecasts.
+
+The port replicates the pipeline that h5↔parquet verification confirmed is the
+producer of the repo's series — variant filter, artificial ▶/■ events, consecutive
+DF pairs bucketed by the **source-event day** — but **drops the 10% end-trim**: the
+live path forecasts the genuine future *from the log end* (ADR-0004), so trimming
+the recent end would be wrong. Fidelity is not an accuracy gate here (the upload
+path reports drift, not accuracy); a single shared feature space is what matters.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from log_to_series import event_df_to_series, log_to_df_series
+
+CASE, ACT, TS = "case:concept:name", "concept:name", "time:timestamp"
+
+
+def _event_df(rows):
+    """Build a tidy event-log DataFrame from ``(case, activity, "YYYY-MM-DD HH:MM")`` rows."""
+    df = pd.DataFrame(rows, columns=[CASE, ACT, TS])
+    df[TS] = pd.to_datetime(df[TS], utc=True)
+    return df
+
+
+# A 2-case log: c1 spans 01-01..01-02, c2 is all on 01-03. Hand-traced expectation
+# (bucket every DF pair by its SOURCE event's day):
+#   01-01: ▶->A, A->B, B->C        01-02: C->■        01-03: ▶->A, A->B, B->■
+_FIXTURE = [
+    ("c1", "A", "2020-01-01 09:00"),
+    ("c1", "B", "2020-01-01 10:00"),
+    ("c1", "C", "2020-01-02 09:00"),
+    ("c2", "A", "2020-01-03 09:00"),
+    ("c2", "B", "2020-01-03 11:00"),
+]
+
+
+@pytest.fixture
+def series():
+    return event_df_to_series(_event_df(_FIXTURE))
+
+
+def test_index_is_contiguous_daily_over_the_full_span(series):
+    """The index is one row per calendar day across the whole (untrimmed) log span."""
+    assert list(series.index) == list(pd.date_range("2020-01-01", "2020-01-03", freq="D"))
+    # contiguous daily — no gaps, no trimmed ends.
+    assert (series.index.to_series().diff().dropna() == pd.Timedelta(days=1)).all()
+
+
+def test_columns_are_df_relations_with_artificial_markers(series):
+    """Columns are ``"a -> b"`` DF relations, including the artificial ▶ / ■ markers."""
+    cols = set(series.columns)
+    assert {"▶ -> A", "A -> B", "B -> C", "C -> ■", "B -> ■"} == cols
+    assert all(" -> " in c for c in cols)  # the exact separator dfg_to_json splits on
+
+
+def test_relations_bucket_on_the_source_event_day(series):
+    """Each DF pair is counted on the day of its *source* event (pmf-benchmark semantics)."""
+    assert series.at[pd.Timestamp("2020-01-01"), "A -> B"] == 1
+    assert series.at[pd.Timestamp("2020-01-03"), "A -> B"] == 1
+    assert series.at[pd.Timestamp("2020-01-02"), "A -> B"] == 0
+
+
+def test_cross_day_relation_counts_on_the_source_not_target_day(series):
+    """B(01-01)->C(01-02) is a cross-day pair; it counts on 01-01 (source), not 01-02."""
+    assert series.at[pd.Timestamp("2020-01-01"), "B -> C"] == 1
+    assert series.at[pd.Timestamp("2020-01-02"), "B -> C"] == 0
+
+
+def test_end_event_relation_counts_on_its_source_day(series):
+    """C->■ (c1's close) buckets on C's day (01-02); the live path keeps that final day."""
+    assert series.at[pd.Timestamp("2020-01-02"), "C -> ■"] == 1
+
+
+def test_log_to_df_series_reads_xes(tmp_path):
+    """The public entry reads an XES file and yields the same frame as the in-memory path."""
+    import pm4py
+
+    df = _event_df(_FIXTURE)
+    xes = tmp_path / "tiny.xes"
+    pm4py.write_xes(df, str(xes), case_id_key=CASE)
+
+    from_file = log_to_df_series(xes)
+    in_memory = event_df_to_series(df)
+    # Same relations and same per-day counts (column/row order aside).
+    a = from_file.reindex(sorted(from_file.columns), axis=1).sort_index()
+    b = in_memory.reindex(sorted(in_memory.columns), axis=1).sort_index()
+    pd.testing.assert_frame_equal(a, b, check_dtype=False)

--- a/docs/adr/0005-pre-rendered-svgs-in-git.md
+++ b/docs/adr/0005-pre-rendered-svgs-in-git.md
@@ -25,3 +25,21 @@ regenerable source of truth**; the SVGs are a derived, committed artifact.
   can replace the committed SVGs without touching the asset contract.
 - This supersedes the "no SVG blobs in git" wording in PRD #65; that PRD is closed, so the decision
   lives here.
+
+## Amendment (slice 3b, #115): the live tab brings `dot` + model libs at serve time
+
+Pre-rendering only covers the **bundled** path, whose assets are known ahead of time. The **live
+upload** tab (#115) forecasts an arbitrary uploaded log on ZeroGPU and must render *its* DFGs at
+request time — there is nothing to pre-render. So the Space's serve-time deps are no longer
+gradio-only: `requirements.txt` now also carries `graphviz` (+ a `packages.txt` for the system `dot`
+binary), `numpy`/`pandas`/`pm4py`, `torch`/`chronos-forecasting`, and the `spaces` GPU shim.
+
+The original reasoning still holds for the bundled path, and two invariants preserve its spirit:
+
+- **The bundled path stays pre-rendered and import-pure.** `import forecast` pulls in none of
+  graphviz/render/`pmf_tsfm`; the bundled tab serves committed SVGs with no `dot` at its request time.
+- **The Space never installs `pmf_tsfm`.** The live path reuses only lean, vendored demo modules
+  (`dfg_build`, `log_to_series`, `forecast_live`) — not the package's heavy model/uni2ts/wandb tree.
+  `precompute_demo.py` (which does import `pmf_tsfm`) is kept off the Space.
+
+Both invariants are pinned by `demo/tests/test_deploy.py`.


### PR DESCRIPTION
Closes #115. Slice 3b of the demo (PRD #112) — the **visual-review round**: wire the custom-upload **live path** end to end and onto **ZeroGPU**.

## What this does
Upload an XES log → forecast its genuine next week **from the log end** → read the **drift** of that forecast vs the **last-known window** (DF relations added/dropped). Per ADR-0004 the upload path reports **drift, never accuracy** (no future truth to score against).

## Highlights
- **`log_to_series.py`** — faithful in-repo port of the external `pmf-benchmark` preprocessing (variant filter → artificial ▶/■ events → consecutive DF pairs bucketed by **source-event day**) that produced this repo's `data/time_series/*.parquet`. Verified the committed pmf-benchmark `time_series_df.h5` is **byte-identical** to the repo parquets (BPI2017, BPI2019_1), confirming the port reproduces the same representation. Deliberately **drops the 10% end-trim** — the live path forecasts from the true log end.
- **`forecast_live._live_windows`** — the seam: daily DF series → Chronos-2 forecast window + actual last-known tail, in one feature space. Guards for too-short logs and not-yet-wired models. `warm_up()` loads Chronos-2 on `cuda` at startup (HF ZeroGPU guidance) so each ~120s call spends its budget on inference, not a cold load.
- **`dfg_build.py`** — extracts the pure DFG-JSON builders so the live path needs **no `pmf_tsfm`** at serve time (`precompute_demo` reuses them).
- **`render.diff_svg(framing="drift")`** — relabels the legend to "forecast | last-known window" / "% change from recent past"; never "actual"/accuracy. `forecast_live` passes it, so the returned SVGs stay honest for the future MCP tool too.
- **`app.py`** — new **Live upload** tab under `@spaces.GPU` (import-guarded so it's a no-op off-Space): upload widget, Chronos-2-only picker, twin panes + drift view + tally, clear guard/error messages.
- **Serve env** — `requirements.txt` + `packages.txt` (graphviz), README `suggested_hardware: zero-a10g`; deploy workflow ships the live modules (not `precompute_demo`, which imports `pmf_tsfm`). Serve-contract tests evolved (bundled core stays import-pure; the Space never installs `pmf_tsfm`). **ADR-0005 amended**.

## Scope this slice (with maintainer)
- **Chronos-2 only**; moirai2/timesfm2.5 stay gated (follow-up).
- GUI verified locally with **stubbed inference**; real on-GPU inference is verified post-merge.

## HITL ⚠️
- This needs the maintainer to **upgrade the Space to ZeroGPU (PRO) hardware** manually after merge.
- The real on-GPU run + 120s-budget check happens after that flip.

## Tests
- `uv run pytest demo/tests/` → **65 passed, 12 skipped** (CI parity, no gradio)
- `uv run --with gradio pytest demo/tests/` → **77 passed**
- `ruff check` + `ruff format --check` clean.
- End-to-end locally (real converter + render + drift, model stubbed): twin panes render, drift legend never says "actual", oversize/too-short uploads rejected clearly.

Follow-up: #116 flips `mcp_server=True` after this merges.