### PR TITLE
fix(demo): load Chronos-2 inside @spaces.GPU, not at import (ZeroGPU pid=0)

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import gradio as gr
 from forecast import forecast_bundled
-from forecast_live import forecast_live, warm_up
+from forecast_live import forecast_live
 from upload_guard import UploadRejected
 
 # Only the precomputed bundled pairs are offered as choices: the full 4-by-3 matrix.
@@ -40,6 +40,16 @@ LIVE_MODELS: list[str] = ["chronos2"]
 # ZeroGPU boundary: ``@spaces.GPU`` requests a GPU slice for the ~120s of the live call
 # (ADR-0001). ``spaces`` only exists on the HF Space, so off-Space (local / CI) we fall
 # back to a no-op decorator and the same code runs on CPU for the visual check.
+#
+# IMPORTANT — do NOT load the model on cuda at module import. ZeroGPU forks a worker per
+# @spaces.GPU call; if CUDA is initialised in *this* (parent) process first, the fork's
+# process tracking fails with "process PID not found (pid=0)". HF's "load on cuda at
+# module level" guidance relies on the emulation intercepting `.to('cuda')`, which it does
+# for standard transformers/diffusers — but NOT for the autogluon Chronos-2 loader
+# (`BaseChronosPipeline.from_pretrained(device_map="cuda")`), which inits real CUDA in the
+# parent and breaks the fork. So Chronos-2 is loaded lazily INSIDE the @spaces.GPU call
+# (see forecast_live._chronos2_forecast), where a real GPU exists. The weights cache to disk
+# on first download, so later calls are fast.
 try:
     import spaces
 
@@ -48,14 +58,6 @@ except ImportError:  # pragma: no cover - exercised only off-Space
 
     def _gpu(fn):  # type: ignore[no-redef]
         return fn
-else:  # pragma: no cover - exercised only on the Space
-    # On ZeroGPU, warm-load Chronos-2 on cuda at import (HF guidance), so each call's
-    # ~120s budget is spent on inference, not a cold download/load. Non-fatal: if the
-    # startup load fails the first request falls back to a lazy load.
-    try:
-        warm_up("cuda")
-    except Exception as err:  # never block app startup on a warm-up miss
-        print(f"Chronos-2 warm-up skipped ({err}); will lazy-load on first request.")
 
 
 @_gpu

--- a/demo/forecast_live.py
+++ b/demo/forecast_live.py
@@ -29,44 +29,30 @@ from render import dfg_json_to_svg, diff_svg
 # moirai2 / timesfm2.5 stay a documented follow-up. The id matches
 # configs/model/chronos/chronos2.yaml. Loading an ``s3://`` checkpoint needs boto3.
 _CHRONOS2_MODEL_ID = "s3://autogluon/chronos-2/"
-_chronos2_pipeline: object | None = None  # module-level cache, loaded once per process
+_chronos2_pipeline: object | None = None  # cache, loaded once per (forked) worker process
 
 
-def _load_chronos2(device: str | None = None) -> object:
+def _load_chronos2() -> object:
     """Load (and cache) the Chronos-2 pipeline. Imports torch/chronos lazily so the
     live-core module stays importable — and testable — without the model libs.
 
-    Args:
-        device: the device to place the model on. ``None`` (the default, used by the
-            per-call path) auto-detects: real ``cuda`` inside a ``@spaces.GPU`` call,
-            else ``cpu``. :func:`warm_up` passes ``"cuda"`` explicitly so the startup
-            load targets the GPU even under ZeroGPU's module-level CUDA emulation, where
-            ``torch.cuda.is_available()`` is ``False``.
+    **Called only from inside the ``@spaces.GPU`` worker** (via :func:`_chronos2_forecast`),
+    never at module import: ZeroGPU forks a worker per GPU call, and initialising CUDA in
+    the parent process (e.g. an eager ``device_map="cuda"`` load at import) breaks that fork
+    with "process PID not found (pid=0)". So the model is loaded on the real GPU that exists
+    inside the worker; ``torch.cuda.is_available()`` is ``True`` there. The weights cache to
+    disk on first download, so subsequent workers load fast.
     """
     global _chronos2_pipeline
     if _chronos2_pipeline is None:
         import torch
         from chronos import BaseChronosPipeline
 
-        if device is None:
-            device = "cuda" if torch.cuda.is_available() else "cpu"
+        device = "cuda" if torch.cuda.is_available() else "cpu"
         _chronos2_pipeline = BaseChronosPipeline.from_pretrained(
             _CHRONOS2_MODEL_ID, device_map=device
         )
     return _chronos2_pipeline
-
-
-def warm_up(device: str = "cuda") -> None:
-    """Eagerly load Chronos-2 at startup so per-call GPU time is spent on inference only.
-
-    HF ZeroGPU guidance is to load models on ``cuda`` at **module level** (it emulates
-    CUDA outside ``@spaces.GPU`` so the placement is cheap), not lazily inside the GPU
-    function — otherwise the *first* request pays the cold model download/load out of its
-    ~120s ``duration`` budget and may time out. The Space calls this once at import (see
-    ``app.py``); off-Space it is simply never called, and the per-call path lazy-loads on
-    CPU instead.
-    """
-    _load_chronos2(device=device)
 
 
 def _chronos2_forecast(context: np.ndarray, horizon: int) -> np.ndarray:

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -180,19 +180,6 @@ def test_live_windows_rejects_log_with_too_little_history(tmp_path, monkeypatch)
         forecast_live._live_windows(tmp_path / "x.xes", "chronos2", 7)
 
 
-def test_warm_up_loads_the_model_on_the_given_device(monkeypatch):
-    """warm_up eagerly loads Chronos-2 on the requested device (HF ZeroGPU guidance:
-    load at module level on cuda, not lazily inside the GPU call)."""
-    import forecast_live
-
-    captured = {}
-    monkeypatch.setattr(
-        forecast_live, "_load_chronos2", lambda device=None: captured.update(device=device)
-    )
-    forecast_live.warm_up("cuda")
-    assert captured == {"device": "cuda"}
-
-
 def test_live_windows_rejects_unwired_model_before_preprocessing(tmp_path, monkeypatch):
     """Only chronos2 is wired this slice; a gated model is rejected before any work runs."""
     import forecast_live


### PR DESCRIPTION
Follow-up to #119 (slice 3b). The live forecast failed on the ZeroGPU Space with **`process PID not found (pid=0)`** — surfaced during the HITL on-GPU verification that slice 3b deferred (stubbed inference couldn't catch it).

## Cause
ZeroGPU forks a worker process per `@spaces.GPU` call. The `warm_up("cuda")` added in #119 (to dodge the first-call cold load) loaded Chronos-2 on `cuda` **at module import**, initialising CUDA in the **parent** process — which breaks ZeroGPU's per-call fork/PID tracking (`pid=0`).

HF's "load on cuda at module level" guidance relies on the ZeroGPU emulation intercepting `.to('cuda')`. That holds for standard `transformers`/`diffusers`, but **not** for the autogluon Chronos-2 loader (`BaseChronosPipeline.from_pretrained(device_map="cuda")`), which inits real CUDA in the parent.

## Fix
- Remove `warm_up` entirely (and its call in `app.py`, and its test).
- Load Chronos-2 **lazily inside the `@spaces.GPU` worker** (`forecast_live._chronos2_forecast` → `_load_chronos2`), where a real GPU exists. Weights cache to disk on first download, so later workers load fast.
- Trade-off: gives up the per-call cold-load optimisation in favour of a working GPU path. A clear comment in `app.py` warns against re-introducing a module-level cuda load.

The app/upload/guard/UI were already fine — only the GPU call failed inside the `spaces` machinery.

## Tests
- `uv run pytest demo/tests/` → 64 passed, 12 skipped
- `uv run --with gradio pytest demo/tests/` → 76 passed
- ruff clean.

⚠️ Real on-GPU verification still requires merging (auto-deploy) + a forecast on the ZeroGPU Space — the maintainer will re-test there.