### PR TITLE
feat(demo): finish live tab UX — example log, progress, onboarding, caps

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -39,14 +39,15 @@ jobs:
         # Explicit allow-list: only what the running app reads. Anything not copied here never
         # reaches the Space. The bundled path needs app + forecast + assets; the live path adds the
         # vendored modules forecast_live imports (render, dfg_build, dfg_diff, log_to_series,
-        # upload_guard) + packages.txt. The precompute module is excluded (it imports pmf_tsfm).
+        # upload_guard) + packages.txt + the one-click example log (examples/). The precompute
+        # module is excluded (it imports pmf_tsfm).
         run: |
           set -euo pipefail
           rm -rf _space && mkdir -p _space
           cp demo/app.py demo/forecast.py demo/forecast_live.py demo/upload_guard.py \
              demo/log_to_series.py demo/dfg_build.py demo/dfg_diff.py demo/render.py \
              demo/requirements.txt demo/packages.txt demo/README.md _space/
-          cp -r demo/static demo/assets _space/
+          cp -r demo/static demo/assets demo/examples _space/
           echo "Staged for the Space:"
           find _space -maxdepth 2 -type f | sort
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -27,7 +27,7 @@ from typing import Any
 import gradio as gr
 from forecast import forecast_bundled
 from forecast_live import forecast_live
-from upload_guard import UploadRejected
+from upload_guard import MAX_UPLOAD_BYTES, SMALL_LOG_BYTES, UploadRejected
 
 # Only the precomputed bundled pairs are offered as choices: the full 4-by-3 matrix.
 DATASETS: list[str] = ["bpi2017", "bpi2019_1", "sepsis", "hospital_billing"]
@@ -36,6 +36,10 @@ MODELS: list[str] = ["chronos2", "moirai2", "timesfm2.5"]
 # The live path runs on ZeroGPU. Only Chronos-2 is wired this slice (#115); moirai2 /
 # timesfm2.5 stay gated (a follow-up), so the live picker offers Chronos-2 alone.
 LIVE_MODELS: list[str] = ["chronos2"]
+
+# A tiny committed sample (a dense six-week slice of the bundled sepsis log) so the live
+# tab has a one-click "Try an example" — no one needs their own XES to see the path work.
+EXAMPLE_LOG = Path(__file__).resolve().parent / "examples" / "sepsis_sample.xes"
 
 # ZeroGPU boundary: ``@spaces.GPU`` requests a GPU slice for the ~120s of the live call
 # (ADR-0001). ``spaces`` only exists on the HF Space, so off-Space (local / CI) we fall
@@ -218,30 +222,70 @@ def _drift_summary(drift: dict[str, list[dict[str, Any]]]) -> str:
 # Blank panes + cleared summary, reused when an upload is rejected or absent.
 _LIVE_BLANK: tuple[str, str, str, str, str] = ("", "", "", "", "")
 
+# Shown the instant Forecast is pressed, before the (slow, cold-loading) GPU call returns,
+# so the live tab never just sits frozen for ~120s. Yielded ahead of the result below.
+_LIVE_WORKING = (
+    "⏳ Forecasting on ZeroGPU — the first call cold-loads Chronos-2 (this can take ~60s); "
+    "later calls are fast. Hold on…"
+)
 
-def run_live(log_path: str | None, model: str) -> tuple[str, str, str, str, str, str]:
-    """Forecast an uploaded log and assemble the live-tab outputs.
 
-    Returns ``(status_md, forecast_html, comparison_html, diff_abs_html, diff_rel_html,
+def run_live(log_path: str | None, model: str):
+    """Forecast an uploaded log and stream the live-tab outputs.
+
+    A generator: it **yields an interim "working" state immediately** (so the UI shows
+    progress, not a frozen pane, while the ~120s ZeroGPU call runs), then yields the final
+    ``(status_md, forecast_html, comparison_html, diff_abs_html, diff_rel_html,
     drift_summary_md)``. A guard rejection (oversize / gated model / too-short log) or any
     other failure short-circuits to a clear status message with blank panes — the GPU is
     only reached for an accepted upload.
     """
     if not log_path:
-        return ("⬆️ Upload an XES event log, then press **Forecast**.", *_LIVE_BLANK)
+        yield (
+            "⬆️ Upload an XES event log (or pick the example), then press **Forecast**.",
+            *_LIVE_BLANK,
+        )
+        return
+    yield (_LIVE_WORKING, *_LIVE_BLANK)
     try:
         result = _run_live(log_path, model)
     except UploadRejected as rejected:
-        return (f"⚠️ Upload rejected: {rejected}", *_LIVE_BLANK)
+        yield (f"⚠️ Upload rejected: {rejected}", *_LIVE_BLANK)
+        return
     except Exception as err:
-        return (f"⚠️ Could not forecast this log: {err}", *_LIVE_BLANK)
-    return (
+        yield (f"⚠️ Could not forecast this log: {err}", *_LIVE_BLANK)
+        return
+    yield (
         "✅ Forecast complete — showing the genuine next week vs the last-known window.",
         _scrollable(result["forecast_svg"]),
         _scrollable(result["comparison_svg"]),
         _scrollable(result["diff_absolute_svg"]),
         _scrollable(result["diff_relative_svg"]),
         _drift_summary(result["drift"]),
+    )
+
+
+def _example_note() -> str:
+    """Frame the one-click example so it doesn't read as a duplicate of the bundled sepsis
+    entry: it is a ready-made **stand-in for your own upload**, and the live path forecasts
+    *this slice's* genuine next week — distinct from the Bundled tab's backtest of the full log.
+    """
+    return (
+        "The example is a six-week slice of the **sepsis** log (one of the bundled datasets), a "
+        "ready-made stand-in for your own upload — the live path forecasts *this slice's* genuine "
+        "next week and its drift. The **Bundled explorer** tab instead backtests the *full* sepsis "
+        "log against known truth."
+    )
+
+
+def _live_caps_note() -> str:
+    """The upload limits shown on the live tab, **derived** from the guard constants so the
+    displayed caps can never drift from what ``upload_guard.check_upload`` actually enforces.
+    """
+    return (
+        f"**Limits** — max upload **{MAX_UPLOAD_BYTES / 1e6:.1f} MB**. Chronos-2 forecasts any "
+        f"log up to that cap; Moirai-2 / TimesFM-2.5 (when enabled) are limited to logs under "
+        f"**{SMALL_LOG_BYTES / 1e6:.1f} MB** so a single call stays within the GPU time limit."
     )
 
 
@@ -256,9 +300,33 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
         "from the rest, then compared against what actually happened — so ER / MAE / RMSE "
         "are genuine accuracy."
     )
+    with gr.Accordion("What am I looking at?", open=False):
+        gr.Markdown(
+            "A **directly-follows graph (DFG)** summarises a process: each arc *a → b* is a "
+            "**directly-follows (DF) relation** (b directly follows a), the number on it the "
+            "count over the week.\n\n"
+            "- **Forecast** — the held-out last week, as the model predicted it from prior weeks.\n"
+            "- **Actual future** — what really happened that week.\n"
+            "- **ER / MAE / RMSE** — how accurate the forecast was against that actual future. "
+            "**Entropic Relevance (ER)** scores how well a DFG explains the real behaviour "
+            "(lower is better; the *truth (baseline)* box is the ER of the actual DFG itself — the "
+            "floor to beat). **MAE / RMSE** measure the DF-frequency error.\n\n"
+            "Accuracy is meaningful here because the actual future is known. The **Live upload** "
+            "tab forecasts a genuinely unseen future instead, so it reports **drift, never accuracy**."
+        )
     with gr.Row():
-        dataset = gr.Dropdown(DATASETS, value=DATASETS[0], label="Dataset")
-        model = gr.Dropdown(MODELS, value=MODELS[0], label="Model")
+        dataset = gr.Dropdown(
+            DATASETS,
+            value=DATASETS[0],
+            label="Dataset",
+            info="One of the paper's four event logs",
+        )
+        model = gr.Dropdown(
+            MODELS,
+            value=MODELS[0],
+            label="Model",
+            info="The time-series foundation model that produced the forecast",
+        )
     view = gr.Radio(["Side-by-side", "Diff"], value="Side-by-side", label="View")
     with gr.Row(visible=True) as twin_panes:
         with gr.Column():
@@ -317,16 +385,46 @@ def _build_live_tab() -> None:
         "Upload a custom **XES** log to forecast its genuine next week (forecast origin = "
         "the log end) on ZeroGPU, then read the **drift** of that forecast vs the "
         "**last-known window** — DF relations the forecast adds or drops. There is no "
-        "future truth for an upload, so this path shows **drift, never accuracy** "
-        "(ADR-0004).  Default **Chronos-2**; large logs and heavy models are capped so a "
-        "call stays under the GPU time limit."
+        "future truth for an upload, so this path shows **drift, never accuracy** (ADR-0004)."
     )
+    with gr.Accordion("What am I looking at?", open=False):
+        gr.Markdown(
+            "Each arc *a → b* in a **directly-follows graph (DFG)** is a **directly-follows "
+            "(DF) relation** (b directly follows a). The live path forecasts the **genuine next "
+            "week** from your log's end and compares it to the **last-known window** (its recent "
+            "past):\n\n"
+            "- **Forecast** — the predicted next week's DFG.\n"
+            "- **Last-known window** — the most recent week already in your log.\n"
+            "- **Drift** — the DF relations the forecast **adds** or **drops** vs that recent past.\n\n"
+            "No accuracy metric (ER / MAE / RMSE) is shown: an upload has no future ground truth to "
+            "score against (ADR-0004). For scored accuracy, see the **Bundled explorer** tab."
+        )
     with gr.Row():
         upload = gr.File(label="XES event log", file_types=[".xes"], type="filepath")
-        live_model = gr.Dropdown(LIVE_MODELS, value=LIVE_MODELS[0], label="Model")
+        live_model = gr.Dropdown(
+            LIVE_MODELS,
+            value=LIVE_MODELS[0],
+            label="Model",
+            info="Chronos-2 is wired on the hosted GPU; more models are a follow-up",
+        )
         run = gr.Button("Forecast", variant="primary")
-    status = gr.Markdown("⬆️ Upload an XES event log, then press **Forecast**.")
-    view = gr.Radio(["Side-by-side", "Drift"], value="Side-by-side", label="View")
+    gr.Examples(
+        examples=[[str(EXAMPLE_LOG)]],
+        inputs=[upload],
+        label="Try an example — a six-week slice of the sepsis log",
+        cache_examples=False,
+    )
+    gr.Markdown(_example_note())
+    gr.Markdown(_live_caps_note())
+    status = gr.Markdown(
+        "⬆️ Upload an XES event log (or pick the example), then press **Forecast**."
+    )
+    view = gr.Radio(
+        ["Side-by-side", "Drift"],
+        value="Side-by-side",
+        label="View",
+        info="Side-by-side: forecast vs last-known window. Drift: their overlay.",
+    )
     with gr.Row(visible=True) as twin_panes:
         with gr.Column():
             gr.Markdown("### Forecast — the genuine next week, predicted")

--- a/demo/examples/sepsis_sample.xes
+++ b/demo/examples/sepsis_sample.xes
@@ -1,0 +1,7885 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<log xes.version="1849-2016" xes.features="nested-attributes" xmlns="http://www.xes-standard.org/">
+	<extension name="Concept" prefix="concept" uri="http://www.xes-standard.org/concept.xesext" />
+	<extension name="Time" prefix="time" uri="http://www.xes-standard.org/time.xesext" />
+	<string key="origin" value="csv" />
+	<trace>
+		<string key="concept:name" value="F" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T18:56:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T18:57:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T18:58:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T19:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T19:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T19:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T22:01:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-07T22:01:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T22:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-09T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="U" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-29T20:38:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-29T21:39:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-29T21:49:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T22:02:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T23:01:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T09:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T10:23:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T10:23:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release B" />
+			<date key="time:timestamp" value="2014-05-01T19:10:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T17:36:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T18:04:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T18:04:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-07T18:05:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T18:05:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T18:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T18:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T18:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T21:07:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-12T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-08T12:28:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-08T12:42:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-08T12:45:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T13:02:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T13:02:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-08T13:02:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-08T16:28:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-08T16:28:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-08T16:29:17+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-12T16:30:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-12T16:32:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T18:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T18:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T18:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-12T20:39:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-12T22:17:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-12T22:17:45+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T08:37:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T08:49:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T08:54:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T09:00:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T09:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T09:17:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T09:17:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T09:17:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T12:11:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-07T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-05T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ZA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-24T11:32:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-24T11:45:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-24T11:46:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T12:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-24T12:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T12:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-24T12:40:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-24T12:40:56+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="DB" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-04T11:56:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-04T11:59:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-04T12:00:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T12:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-04T12:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T12:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-04T15:39:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-04T15:39:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-04T15:40:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FB" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-21T17:02:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-21T17:07:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-21T17:24:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-21T17:24:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-21T17:24:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-21T17:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T17:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-21T17:34:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SB" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-01T10:17:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-01T10:25:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-01T10:25:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-01T10:25:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-01T10:25:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T10:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T10:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T10:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-01T12:26:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T15:00:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-10T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ZB" />
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T11:33:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-01T15:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="HC" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-29T20:06:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-29T20:12:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-29T20:14:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T20:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T20:41:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KC" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-05T08:25:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-05T08:34:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-05T08:34:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-05T08:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-05T09:13:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-05T09:14:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-05T11:15:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="LC" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T06:09:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T06:10:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T06:18:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T06:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T06:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T06:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-02T08:18:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T08:32:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T15:00:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-24T10:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-26T08:25:58+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="WC" />
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-04-28T11:20:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-28T12:18:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-28T12:23:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-28T12:25:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-28T12:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T12:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T12:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-04-28T15:21:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-28T15:22:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-28T17:49:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-01T13:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-08T19:20:37+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FD" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T22:26:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T22:28:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T22:29:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T22:36:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T22:36:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T22:36:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-10T22:51:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-10T23:51:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="OD" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-27T03:53:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T04:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T04:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-27T04:06:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-27T04:07:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-27T05:33:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-27T05:33:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-27T05:36:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T06:59:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T06:59:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T06:59:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T13:21:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-28T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PD" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-03T14:28:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T14:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-03T14:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T14:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-03T14:47:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-03T14:47:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-03T14:47:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-03T14:47:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T16:45:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YD" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T12:46:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T13:05:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T13:05:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T13:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T13:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T13:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-07T14:21:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T14:21:48+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ME" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-18T00:24:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-18T00:28:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T00:37:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-18T00:37:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T00:37:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-18T00:56:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-18T00:57:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-18T00:57:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-18T02:20:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-22T19:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="UE" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-23T20:22:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-23T20:31:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-23T20:32:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-23T20:37:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-23T20:44:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-23T20:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-23T20:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-23T20:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-23T23:53:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-24T12:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-30T10:20:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="CF" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-12T13:10:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-12T13:14:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-12T13:16:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T13:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T13:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T13:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-12T16:11:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-12T16:12:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-01T18:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-06-05T12:56:16+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EF" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T18:36:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T18:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T18:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T18:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T18:53:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T18:53:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-02T18:54:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-02T18:54:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T21:49:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-06T15:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GF" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-29T03:22:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-29T03:24:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-29T03:25:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T03:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T03:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T03:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-29T05:38:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-29T05:38:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-29T05:40:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T10:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T10:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T10:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T14:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T14:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T14:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-31T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T23:36:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-04T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="VF" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-26T21:12:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-26T21:14:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-26T21:15:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T21:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-26T21:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-26T21:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-26T23:30:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-26T23:30:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T23:31:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T14:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-30T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ZF" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-05T21:14:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-05T21:21:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-05T21:23:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-05T21:24:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-05T21:24:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T21:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T21:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-05T21:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-06T00:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-06T01:18:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-06T16:32:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AG" />
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T01:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T11:03:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T11:13:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T11:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T11:24:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KG" />
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T12:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T12:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T23:36:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T23:52:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T23:52:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-21T00:04:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T00:04:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-21T00:04:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-21T01:30:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-21T01:30:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-21T03:31:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-21T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-23T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-23T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-24T15:15:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EH" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-12T12:27:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-12T12:33:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-12T12:34:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T13:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T13:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T13:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-12T15:20:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-12T15:20:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-12T15:22:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-17T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KH" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-31T08:12:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-31T08:24:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-31T08:24:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-31T08:35:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T08:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-31T08:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T08:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-31T08:50:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-31T12:08:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-03T13:40:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NH" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-15T12:06:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-15T12:09:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-15T12:09:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T12:28:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-15T12:28:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T12:28:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-15T15:19:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-15T15:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-15T15:20:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-20T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="HI" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-06T16:44:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-06T17:14:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-06T17:27:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-06T18:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T18:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T18:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-06T20:21:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-10T09:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-27T20:35:37+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NI" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-31T18:15:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-31T18:22:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T18:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-31T18:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T18:31:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-31T18:33:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-31T20:40:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-31T20:40:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-31T20:42:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-06T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PI" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T22:44:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T22:57:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T22:57:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T23:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T23:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T23:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-04T02:21:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-04T22:55:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-04T22:56:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-06T17:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YI" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-01T18:40:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-01T18:41:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-01T18:44:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T18:53:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T18:53:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T18:53:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-01T23:12:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-01T23:12:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-01T23:13:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-08T15:50:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IJ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-24T19:40:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-24T19:49:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-24T19:50:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T20:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T20:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-24T20:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-24T23:10:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-24T23:10:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-24T23:12:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T14:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T14:54:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-26T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-31T10:30:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EK" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-11T12:18:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-11T12:28:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-11T12:29:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-11T12:29:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T12:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T12:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-11T12:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-11T15:20:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-11T15:21:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-14T08:38:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release B" />
+			<date key="time:timestamp" value="2014-05-18T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XK" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-15T10:41:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-15T11:11:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-15T11:12:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T11:16:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-15T11:16:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T11:16:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BL" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-06T22:37:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-06T22:45:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-06T22:46:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T23:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T23:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T01:05:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T01:47:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T11:23:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T14:30:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-08T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="LL" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-08T12:46:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-08T12:56:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-08T12:56:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-08T13:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T13:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T13:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-08T13:22:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-08T13:22:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-08T15:31:45+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PL" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T12:14:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T12:42:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T12:42:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T12:42:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:42:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:42:37+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SL" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T11:31:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T11:34:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T11:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T11:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T11:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T12:17:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-02T12:17:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-02T15:13:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T15:15:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T19:05:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-06T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="VL" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-30T05:09:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-30T05:16:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-30T05:16:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T05:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T05:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-30T05:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-30T06:55:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-30T06:55:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-30T06:56:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T10:39:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T10:39:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-02T19:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YM" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T12:34:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-08T12:35:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:38:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:38:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T13:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T13:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T13:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-08T13:33:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-08T15:33:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-13T10:20:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AN" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T19:22:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T19:33:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T19:34:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T19:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T19:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T19:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-21T00:33:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-21T22:32:29+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="MN" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T15:08:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T15:08:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-29T19:46:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-29T19:59:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-29T19:59:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T23:29:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-30T09:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T09:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-04-30T17:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T18:37:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T02:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T02:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T02:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T10:38:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-01T17:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T20:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T06:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T06:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T06:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T13:47:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T21:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-05T10:15:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-07T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-09T11:16:43+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BO" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-30T16:45:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-30T16:54:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-30T16:54:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-30T17:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T17:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T17:10:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KO" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T21:14:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T21:16:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T21:17:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T21:17:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T21:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T21:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T23:11:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T23:17:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-15T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NO" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-14T18:29:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-14T18:32:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-14T18:32:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-14T18:32:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-14T18:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T18:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T18:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-14T20:56:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-14T20:58:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-15T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-17T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YO" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-26T11:54:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-26T11:56:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-26T11:59:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T12:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-26T12:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-26T12:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-26T16:35:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-26T16:35:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T16:36:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T17:15:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-28T08:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-31T15:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-31T15:17:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-31T15:19:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T15:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T15:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-31T17:28:33+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T20:14:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T20:22:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T20:22:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T20:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T20:26:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-12T21:24:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-12T21:26:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-12T21:36:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T21:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T21:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T21:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-13T00:08:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-13T00:08:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-13T02:51:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-15T20:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="RP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-15T19:12:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-15T19:20:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T19:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T19:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-15T21:52:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-15T22:24:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T08:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-19T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-03T14:14:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-03T14:32:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-03T14:33:04+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="TP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-04T13:37:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-04T13:40:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-04T13:41:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T14:09:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T14:09:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-04T14:09:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-04T17:04:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-04T17:04:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-04T17:12:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-05T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="UP" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-16T10:01:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-16T10:08:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-16T10:08:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-16T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-16T12:03:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-16T12:04:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-16T13:24:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-17T18:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-18T19:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AQ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-05T19:43:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-05T19:45:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-05T19:45:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T19:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T19:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-05T19:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-05T23:14:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-05T23:14:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-05T23:15:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NQ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-03T17:36:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-03T17:52:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-03T17:53:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T18:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T18:07:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="CR" />
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-04-28T11:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-27T14:03:53+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IR" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-19T15:21:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-19T15:24:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-19T15:25:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T15:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T15:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-19T15:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-19T15:46:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-19T15:46:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-19T16:09:13+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YR" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T14:20:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T14:28:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T14:29:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T14:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T14:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T14:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T14:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T14:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T16:01:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-01T16:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JS" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-02T11:45:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="RS" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-05T16:34:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-05T16:44:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-05T16:54:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T17:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T17:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-05T17:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-05T19:13:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-05T19:13:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-05T19:13:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-06T08:35:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="TS" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release C" />
+			<date key="time:timestamp" value="2014-05-01T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="CT" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-31T21:46:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-31T21:48:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-31T21:48:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-31T22:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T22:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T22:32:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-01T00:18:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-01T00:19:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-01T21:49:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-06T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FT" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T13:26:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T13:27:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T13:28:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T13:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T13:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T13:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-08T15:11:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-08T15:13:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-15T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-23T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T08:59:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-26T13:45:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GT" />
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-04-29T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-10T17:27:33+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="MT" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-17T19:17:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-17T19:23:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-17T19:48:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T19:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T19:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-17T19:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-17T20:48:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-17T20:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-17T21:53:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-22T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="QT" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-29T19:57:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-29T20:06:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-29T20:15:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T20:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T20:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T20:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-29T23:34:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-29T23:34:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-29T23:35:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EU" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-27T17:50:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-27T17:56:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-27T17:56:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T18:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T18:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T18:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-27T18:07:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-27T18:07:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T22:07:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-31T13:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="UU" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T10:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T10:58:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T10:59:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T11:09:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T12:05:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-10T16:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XU" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T10:04:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T10:24:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T10:24:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T10:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T10:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T10:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-10T10:30:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-10T12:00:54+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IV" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-06T15:37:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-06T16:06:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-06T16:38:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T16:38:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-06T18:04:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-06T18:05:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-06T18:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-06T19:10:08+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="OW" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T16:07:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T16:26:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T16:27:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T17:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T17:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T17:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T19:30:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T19:31:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T19:33:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-10T12:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XW" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T19:51:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T20:02:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T20:03:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T20:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T20:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T20:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-02T21:57:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-02T21:57:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T22:59:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-09T13:08:49+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="MX" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T15:45:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T15:58:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T15:59:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T16:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T16:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T16:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-07T17:26:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T17:26:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T18:27:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-16T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="OX" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-29T10:54:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-29T10:58:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-29T11:04:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T11:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-29T11:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T11:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-04-29T11:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-04-29T11:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T14:37:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-05T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-27T17:09:10+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="WX" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T22:41:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T22:44:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T22:51:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T23:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T23:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T23:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-11T02:25:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-11T23:25:21+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XX" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T10:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T10:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T12:21:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T12:30:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T12:30:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-20T14:39:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-20T14:39:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-20T14:40:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release B" />
+			<date key="time:timestamp" value="2014-05-20T15:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YX" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-29T19:24:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-29T19:27:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-29T19:27:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-04-29T19:27:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-04-29T19:27:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T19:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T19:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-29T19:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T22:27:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-04-30T10:04:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-30T11:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T11:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-30T11:07:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T13:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-06T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-09T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-12T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-13T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-15T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-16T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-18T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-19T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-21T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-21T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-22T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-22T10:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-22T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T13:49:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-29T13:15:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T12:30:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T12:45:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T12:46:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T13:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T13:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T13:24:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="CY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-04T20:02:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-04T20:04:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-04T20:04:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T20:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T20:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-04T20:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-04T21:41:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-04T21:41:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-04T21:41:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-05T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-06-07T18:12:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T18:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-07T18:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T18:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-08T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-02T13:01:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-02T13:07:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-02T13:07:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T13:47:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T13:47:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-02T17:28:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-02T17:33:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-02T17:36:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T09:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release B" />
+			<date key="time:timestamp" value="2014-06-07T20:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-03T18:19:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-03T18:29:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T18:30:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-03T18:47:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T19:07:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T21:09:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-04T12:36:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-19T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T15:47:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T15:49:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T15:50:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T16:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T16:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T16:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-10T19:18:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-10T19:18:37+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SY" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-13T18:14:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-13T18:45:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-13T18:52:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-13T18:52:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-13T18:52:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-13T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T18:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-13T22:01:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-14T11:35:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-17T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IZ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-07T06:29:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-07T06:33:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-07T06:33:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T06:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T06:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-07T09:09:18+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PZ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-28T11:46:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-28T11:50:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T11:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T11:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-28T11:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-28T12:18:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-04-28T12:19:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-28T14:33:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T17:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release D" />
+			<date key="time:timestamp" value="2014-05-12T09:45:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-19T11:06:45+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="VZ" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-07T15:53:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-07T16:01:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-07T16:31:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T16:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T20:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T20:10:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BBA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-04-28T13:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-09T19:12:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-09T19:45:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-09T19:45:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T19:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-09T19:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T19:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-09T20:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-09T21:30:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-09T23:58:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-14T13:30:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-02T00:34:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-02T00:42:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-02T00:42:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T00:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T00:43:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="QBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T20:18:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T20:23:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T20:33:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T20:33:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T20:33:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T21:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T21:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T21:50:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-26T00:47:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-26T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-26T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-26T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-26T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-26T21:33:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T11:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T11:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-03T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="TBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T04:31:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T04:33:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T04:34:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T05:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T05:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T05:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-08T05:00:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-08T05:00:43+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-08T07:02:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-11T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="UBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T11:58:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:07:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T12:07:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-08T12:07:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T12:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T12:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T12:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-08T14:06:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-08T14:08:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-23T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="VBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T13:53:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T14:05:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T14:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T14:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T14:28:56+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-04-28T21:27:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-04-28T21:37:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-04-28T21:37:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T21:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-28T21:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T21:44:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T01:54:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-04-29T04:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-04-29T05:07:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-29T05:35:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T05:35:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T05:35:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T13:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-29T13:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-04-29T22:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-04-29T22:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-04-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-01T12:34:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T12:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-10T20:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YBA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-19T18:49:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-19T18:51:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-19T18:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T19:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T19:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-19T19:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-19T20:05:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-19T23:06:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-19T23:06:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-21T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-21T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-26T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="CCA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-05T11:40:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-05T11:42:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-05T11:43:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T11:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T11:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-05T11:52:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-05T12:19:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-05T15:00:53+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="DCA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T12:31:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T12:34:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T12:34:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T12:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T12:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T12:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-20T14:44:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-20T15:44:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-20T15:48:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-23T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ECA" />
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-04-30T09:04:38+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="HCA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T15:56:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T16:02:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T16:03:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-10T16:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T16:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T16:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T16:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-10T16:15:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="LCA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-22T12:44:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-22T13:09:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-22T13:10:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-22T13:10:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T13:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T13:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-22T13:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-22T16:01:56+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="VCA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-14T23:42:35+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-14T23:45:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-14T23:45:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-14T23:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T23:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T23:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-14T23:57:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-15T00:30:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-15T02:08:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-18T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="WCA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-04-28T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-04-28T15:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FDA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-13T23:00:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-13T23:03:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-13T23:03:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-13T23:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-13T23:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-13T23:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-14T01:37:40+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-14T01:39:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-14T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-14T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-14T12:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-14T23:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-20T12:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-05-29T13:27:22+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="KDA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-11T14:09:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-11T14:21:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-11T14:21:21+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ODA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-02T10:13:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-02T10:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-02T10:26:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-02T10:26:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-02T10:26:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-02T10:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-02T10:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-02T10:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-02T15:08:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-05T13:52:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="TDA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-11T21:45:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-11T22:12:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-11T22:13:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-11T22:13:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-11T22:14:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T22:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T22:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-11T22:46:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-12T01:37:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-14T16:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BEA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T13:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-29T13:32:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-29T13:34:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-29T13:52:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-29T13:53:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-29T13:53:10+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="HEA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-27T03:52:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-27T04:10:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-27T04:11:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-27T04:11:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T04:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T04:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T04:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-27T06:46:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T06:46:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-01T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-06-01T20:59:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-01T21:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-01T21:26:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GFA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T22:39:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T23:01:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T23:01:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T23:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T23:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T23:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T03:20:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T03:21:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T03:21:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-04T13:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="MFA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-29T21:08:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-29T21:17:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T21:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T21:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-29T21:34:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-29T21:48:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-29T21:49:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-29T21:49:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-29T23:52:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-05T20:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PFA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-01T15:53:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-01T15:58:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-01T15:59:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-01T15:59:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-01T15:59:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-01T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-01T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-01T19:03:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-01T21:40:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T12:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-07T13:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="RFA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-09T05:50:20+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-09T05:50:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-09T05:51:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-09T05:51:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-09T05:51:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-09T05:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T05:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T05:58:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-09T08:28:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release B" />
+			<date key="time:timestamp" value="2014-05-10T09:15:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="YGA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T17:28:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T17:30:17+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T17:30:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T17:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T17:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T17:41:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T20:50:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T20:51:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T20:51:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T12:28:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-30T10:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T21:53:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T22:14:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T22:14:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-20T22:15:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T22:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T22:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T22:22:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-20T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-21T02:01:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-22T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-23T12:41:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T06:59:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T07:07:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T07:07:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-02T07:08:16+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T07:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T07:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T07:13:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-02T07:15:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-02T11:13:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-07T15:20:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="GHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-07T15:22:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-07T15:25:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-07T15:26:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T16:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T16:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-07T16:25:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T17:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T17:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-07T17:10:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-07T19:16:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-07T19:16:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-07T19:18:39+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-07T17:25:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-07T17:34:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-07T17:35:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-07T18:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-07T18:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-07T18:51:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-07T19:12:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-07T19:12:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-07T20:32:02+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-04T16:39:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-04T16:45:36+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-04T16:45:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T19:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-04T20:18:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-07T18:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XHA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-16T22:25:01+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-16T22:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-16T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-17T00:10:23+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-17T00:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-17T00:11:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission IC" />
+			<date key="time:timestamp" value="2014-05-17T00:24:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-17T07:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T18:20:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T18:24:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T18:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T18:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T18:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T18:36:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T21:58:37+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T21:58:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T21:59:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T23:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T02:14:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-26T15:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T16:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-29T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="EIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-09T10:55:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-09T11:00:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-09T11:00:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-09T11:12:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T11:12:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-09T11:12:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-09T13:30:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-09T13:30:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-09T13:31:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-12T09:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JIA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T12:14:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T12:14:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-24T17:27:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-24T17:43:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-24T17:47:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T18:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T18:26:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-24T19:15:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-24T19:15:30+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-20T10:26:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-20T10:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-20T10:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-20T10:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-20T11:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-20T11:01:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-20T11:02:58+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-20T11:05:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="TIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-29T13:16:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-29T13:47:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-29T13:47:38+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T14:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T14:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-29T16:40:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-29T19:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-03T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-06-07T11:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-24T18:37:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-24T18:53:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-24T18:54:05+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-24T19:05:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-24T19:05:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ZIA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-08T17:53:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-08T17:55:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-08T17:55:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T18:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T18:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-08T18:20:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-08T20:46:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-08T20:46:30+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="AJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-18T00:07:04+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-18T00:21:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-18T00:21:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-18T00:32:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-18T11:46:11+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="FJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T20:47:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T20:57:07+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T20:57:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-02T21:16:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-02T21:16:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-02T21:16:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-03T01:08:39+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-03T01:08:49+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-03T01:09:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-13T10:30:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="IJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-06T20:28:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-06T20:45:53+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-06T20:46:24+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-06T21:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T21:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T21:01:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-06T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-06T22:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T00:22:27+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-05T10:56:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-05T10:57:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-05T10:58:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T12:57:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T12:57:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-05T12:57:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-05T15:55:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-09T17:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="MJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-04T20:55:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-04T21:19:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-04T21:20:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T21:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T21:24:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-05T02:02:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-05T07:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T15:21:48+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T15:24:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T15:25:30+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T16:03:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T17:11:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T17:11:47+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T17:12:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-26T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T14:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-29T15:30:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="QJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-10T02:35:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-10T02:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T02:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T02:48:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-10T02:52:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-10T02:52:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-10T02:53:08+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-10T02:53:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T12:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="SJA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T19:02:22+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T19:05:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T19:05:29+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T19:24:56+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T19:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T19:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T19:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T22:06:06+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-28T20:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Return ER" />
+			<date key="time:timestamp" value="2014-06-05T11:08:57+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="BKA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-27T16:43:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-27T16:50:57+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-27T16:51:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T17:33:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T17:33:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T17:33:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T19:19:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-27T20:08:09+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-27T20:08:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T20:08:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T07:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-28T15:30:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-29T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-31T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-31T13:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="NKA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-06T02:13:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-06T02:14:52+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-06T02:48:02+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-06T02:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T02:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-06T02:49:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-06T04:47:42+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-06T04:48:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-06T04:49:01+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="PKA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-07T02:37:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-07T02:40:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T02:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-07T02:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T02:43:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-07T02:46:25+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-07T03:48:28+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-07T05:55:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-08T16:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-10T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-10T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-11T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-11T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-11T12:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XKA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-25T15:41:21+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-25T15:48:15+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-25T15:48:41+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-25T15:49:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-25T15:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-25T15:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-25T15:54:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-25T16:10:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-25T17:30:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-31T17:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="JLA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-04T06:15:14+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-04T06:17:55+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-04T06:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-04T06:29:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-04T06:55:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-04T07:29:34+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-05-04T07:29:50+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-04T07:29:51+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-04T08:17:12+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-05T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-06T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-06T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-07T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-07T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-08T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-08T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-09T09:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-12T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-12T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-15T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-15T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-19T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-19T14:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="RLA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-27T09:44:26+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-27T09:53:54+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-27T09:55:31+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-27T11:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-27T11:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-05-27T11:18:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-05-27T13:43:19+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-27T13:44:32+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-28T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-30T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-05T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-06T11:53:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-06T11:53:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T08:00:00+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="DMA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-02T17:08:18+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-02T17:26:11+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-02T17:28:02+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="UMA" />
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T12:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T12:06:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-06-08T15:54:03+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-06-08T16:15:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-06-08T16:15:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="LacticAcid" />
+			<date key="time:timestamp" value="2014-06-08T16:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-06-08T16:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-06-08T16:27:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Liquid" />
+			<date key="time:timestamp" value="2014-06-08T16:35:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="IV Antibiotics" />
+			<date key="time:timestamp" value="2014-06-08T16:35:46+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-06-08T18:13:52+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="XMA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-18T00:13:33+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-18T00:26:44+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-18T00:26:56+00:00" />
+		</event>
+	</trace>
+	<trace>
+		<string key="concept:name" value="ANA" />
+		<event>
+			<string key="concept:name" value="ER Registration" />
+			<date key="time:timestamp" value="2014-05-16T17:11:45+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Triage" />
+			<date key="time:timestamp" value="2014-05-16T17:29:59+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="ER Sepsis Triage" />
+			<date key="time:timestamp" value="2014-05-16T17:30:10+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-16T17:42:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-16T17:42:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Admission NC" />
+			<date key="time:timestamp" value="2014-05-16T23:13:13+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Leucocytes" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="CRP" />
+			<date key="time:timestamp" value="2014-05-17T08:00:00+00:00" />
+		</event>
+		<event>
+			<string key="concept:name" value="Release A" />
+			<date key="time:timestamp" value="2014-05-17T16:00:00+00:00" />
+		</event>
+	</trace>
+</log>

--- a/demo/scripts/make_example_log.py
+++ b/demo/scripts/make_example_log.py
@@ -1,0 +1,62 @@
+"""One-off generator for the live-tab example log (not shipped to the Space).
+
+Subsets the bundled sepsis log into a small `demo/examples/sepsis_sample.xes` so the
+live tab has a one-click "Try an example" upload. The sample is a **dense contiguous
+time-window slice** of the log: events are clipped to the densest `WINDOW_DAYS`-day
+window so the daily DF-relation series is active right up to the end (a meaningful
+last-known window + drift, not a sparse tail) while the file stays well under the
+5 MB small-log gate.
+
+Run from the demo/ dir:  uv run --with pm4py python scripts/make_example_log.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pm4py
+
+SRC = Path(__file__).resolve().parents[2] / "data" / "raw_logs" / "sepsis.xes"
+OUT = Path(__file__).resolve().parent.parent / "examples" / "sepsis_sample.xes"
+WINDOW_DAYS = 42  # a six-week slice: dense enough for a rich forecast, small on disk
+
+CASE_KEY = "case:concept:name"
+TS_KEY = "time:timestamp"
+
+
+def main() -> int:
+    df = pm4py.read_xes(str(SRC))
+    df[TS_KEY] = pd.to_datetime(df[TS_KEY], utc=True)
+
+    # Find the densest WINDOW_DAYS window (most events) and clip to it, so the series
+    # is active throughout instead of trailing off into a long sparse tail.
+    day = df[TS_KEY].dt.tz_convert("UTC").dt.tz_localize(None).dt.normalize()
+    per_day = day.value_counts().sort_index()
+    rolled = per_day.rolling(f"{WINDOW_DAYS}D").sum()
+    end = rolled.idxmax()
+    start = end - pd.Timedelta(days=WINDOW_DAYS - 1)
+    window = (day >= start) & (day <= end)
+    sub = df[window].copy()
+    # Keep only cases that still have a directly-follows pair (>= 2 events) in-window.
+    sizes = sub.groupby(CASE_KEY)["concept:name"].transform("size")
+    sub = sub[sizes >= 2].copy()
+    # Drop the heavy per-event diagnostic attributes the live path never reads — only
+    # case id / activity / timestamp matter to log_to_df_series — so the file stays tiny.
+    sub = sub[[CASE_KEY, "concept:name", TS_KEY]].copy()
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    pm4py.write_xes(sub, str(OUT))
+
+    size_mb = OUT.stat().st_size / 1e6
+    span_days = (sub[TS_KEY].max() - sub[TS_KEY].min()).days
+    print(
+        f"wrote {OUT} — {sub[CASE_KEY].nunique()} cases, {len(sub)} events, "
+        f"{size_mb:.2f} MB, window {start.date()}..{end.date()} ({span_days} days)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -27,6 +27,7 @@ from dfg_diff import dfg_diff
 from forecast import forecast_bundled
 from precompute_demo import frequencies_to_dfg_json, precompute_one
 from render import dfg_json_to_svg, diff_svg
+from upload_guard import MAX_UPLOAD_BYTES, SMALL_LOG_BYTES
 
 # ---------------------------------------------------------------------------
 # Shared DFG fixture — a tiny ▶ → A → B → ■ graph
@@ -837,6 +838,21 @@ _LIVE_STUB_BUNDLE = {
 }
 
 
+def _drain(gen):
+    """Consume a ``run_live`` generator, returning its final yielded output tuple."""
+    final = None
+    for item in gen:
+        final = item
+    return final
+
+
+def _markdown_values(blocks) -> list[str]:
+    """Every non-empty gr.Markdown string rendered in a built Blocks app."""
+    import gradio as gr
+
+    return [c.value for c in blocks.blocks.values() if isinstance(c, gr.Markdown) and c.value]
+
+
 def test_app_builds_both_tabs():
     """The app exposes the bundled explorer and the live upload tab side by side."""
     gr = pytest.importorskip("gradio")
@@ -853,7 +869,9 @@ def test_run_live_renders_panes_and_drift_on_success(monkeypatch):
     import app
 
     monkeypatch.setattr(app, "_run_live", lambda log_path, model: _LIVE_STUB_BUNDLE)
-    status, forecast, comparison, diff_abs, diff_rel, summary = app.run_live("up.xes", "chronos2")
+    status, forecast, comparison, diff_abs, diff_rel, summary = _drain(
+        app.run_live("up.xes", "chronos2")
+    )
 
     assert "✅" in status
     for html in (forecast, comparison, diff_abs, diff_rel):
@@ -862,6 +880,22 @@ def test_run_live_renders_panes_and_drift_on_success(monkeypatch):
     assert "adds" in summary and "drops" in summary
     assert "not accuracy" in summary.lower()
     assert "mae" not in summary.lower() and "rmse" not in summary.lower()
+
+
+def test_run_live_yields_interim_progress_before_result(monkeypatch):
+    """Forecast streams an immediate 'working' state (blank panes) before the slow GPU
+    result, so the live tab shows progress instead of freezing for ~120s."""
+    pytest.importorskip("gradio")
+    import app
+
+    monkeypatch.setattr(app, "_run_live", lambda log_path, model: _LIVE_STUB_BUNDLE)
+    states = list(app.run_live("up.xes", "chronos2"))
+
+    assert len(states) >= 2, "expected an interim progress state, then the result"
+    interim_status, *interim_panes = states[0]
+    assert "Forecasting" in interim_status
+    assert interim_panes == ["", "", "", "", ""]  # no stale/partial graph while working
+    assert "✅" in states[-1][0]  # the final state is the completed forecast
 
 
 def test_run_live_surfaces_upload_rejection_with_blank_panes(monkeypatch):
@@ -874,7 +908,7 @@ def test_run_live_surfaces_upload_rejection_with_blank_panes(monkeypatch):
         raise UploadRejected("log is 40.0 MB; the upload cap is 25.0 MB.")
 
     monkeypatch.setattr(app, "_run_live", _reject)
-    status, *panes = app.run_live("big.xes", "chronos2")
+    status, *panes = _drain(app.run_live("big.xes", "chronos2"))
 
     assert "rejected" in status.lower() and "cap" in status
     assert panes == ["", "", "", "", ""]
@@ -885,7 +919,7 @@ def test_run_live_prompts_when_no_file_uploaded():
     pytest.importorskip("gradio")
     import app
 
-    status, *panes = app.run_live(None, "chronos2")
+    status, *panes = _drain(app.run_live(None, "chronos2"))
     assert "Upload" in status
     assert panes == ["", "", "", "", ""]
 
@@ -899,6 +933,61 @@ def test_run_live_reports_unexpected_failure_without_crashing(monkeypatch):
         raise RuntimeError("graphviz exploded")
 
     monkeypatch.setattr(app, "_run_live", _boom)
-    status, *panes = app.run_live("up.xes", "chronos2")
+    status, *panes = _drain(app.run_live("up.xes", "chronos2"))
     assert "Could not forecast" in status
     assert panes == ["", "", "", "", ""]
+
+
+def test_live_tab_offers_example_log(tmp_path):
+    """The live tab ships a one-click example: a small committed log wired to the upload."""
+    gr = pytest.importorskip("gradio")
+    import app
+
+    # The committed sample exists and sits under the small-log gate (a snappy example).
+    assert app.EXAMPLE_LOG.exists(), "the live-tab example log must be committed"
+    assert app.EXAMPLE_LOG.stat().st_size < SMALL_LOG_BYTES
+
+    # It is wired into the UI as a gr.Examples (a gr.Dataset) referencing that file.
+    datasets = [c for c in app.build().blocks.values() if isinstance(c, gr.Dataset)]
+    samples = [str(s) for d in datasets for row in d.samples for s in row]
+    assert any(app.EXAMPLE_LOG.name in s for s in samples), "example not wired to the upload"
+
+
+def test_live_example_is_framed_as_a_stand_in_for_upload():
+    """The example is labelled as a stand-in for the user's own log (not a duplicate of the
+    bundled sepsis entry), keeping the live tab's 'upload your own' framing clear."""
+    pytest.importorskip("gradio")
+    import app
+
+    note = app._example_note()
+    assert "sepsis" in note.lower() and "your own" in note.lower()
+    assert any(note in m for m in _markdown_values(app.build())), (
+        "the example stand-in note must be shown on the live tab"
+    )
+
+
+def test_live_caps_note_is_derived_from_guard_constants():
+    """The caps shown to the user are formatted from the guard constants (single source of
+    truth), and the caption is rendered on the live tab — not a hand-typed number."""
+    pytest.importorskip("gradio")
+    import app
+
+    note = app._live_caps_note()
+    # Same formatting the guard uses in its rejection messages, so the up-front cap is the
+    # exact number a user sees if their upload is refused (upload_guard.py).
+    assert f"{MAX_UPLOAD_BYTES / 1e6:.1f}" in note
+    assert f"{SMALL_LOG_BYTES / 1e6:.1f}" in note
+
+    markdowns = _markdown_values(app.build())
+    assert any(note in m for m in markdowns), "caps note must be shown on the live tab"
+
+
+def test_tabs_carry_onboarding_accordions():
+    """Each tab carries a collapsed 'What am I looking at?' explainer for first-time visitors."""
+    gr = pytest.importorskip("gradio")
+    import app
+
+    accordions = [c for c in app.build().blocks.values() if isinstance(c, gr.Accordion)]
+    explainers = [a for a in accordions if a.label == "What am I looking at?"]
+    assert len(explainers) >= 2, "expected an onboarding accordion on each tab"
+    assert all(not a.open for a in explainers), "the explainer should start collapsed"

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -195,6 +195,8 @@ def test_deploy_workflow_syncs_the_serve_time_subset():
         "packages.txt",
     ):
         assert required in text, f"deploy workflow must sync {required} for the live tab"
+    # The live tab's one-click example log must reach the Space (gr.Examples points at it).
+    assert "demo/examples" in text, "deploy workflow must sync demo/examples for the live example"
     # precompute_demo.py imports pmf_tsfm, which the Space never installs — keep it out.
     assert "precompute_demo.py" not in text, (
         "deploy workflow must not sync precompute_demo.py (it imports pmf_tsfm)"

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -128,6 +128,31 @@ def test_drift_report_uses_recent_not_actual_vocabulary():
     )
 
 
+# --- the committed example log ----------------------------------------------
+
+
+def test_example_log_is_a_usable_live_input():
+    """The live tab's one-click example must be a valid live input: under the small-log
+    gate and spanning enough days that log_to_df_series yields >= horizon+1 rows (so a
+    7-day window can be forecast from prior history, per _live_windows)."""
+    from pathlib import Path
+
+    from log_to_series import log_to_df_series
+
+    example = Path(__file__).resolve().parent.parent / "examples" / "sepsis_sample.xes"
+    assert example.exists(), "the committed example log is missing"
+
+    from upload_guard import SMALL_LOG_BYTES
+
+    assert example.stat().st_size < SMALL_LOG_BYTES
+
+    series = log_to_df_series(example)
+    horizon = 7
+    assert len(series) >= horizon + 1, "example log spans too few days to forecast from"
+    # An active tail (not a sparse trail-off) so the drift view is meaningful.
+    assert series.to_numpy()[-horizon:].sum() > 0
+
+
 # --- _live_windows (the seam: preprocess + forecast) ------------------------
 
 


### PR DESCRIPTION
## What & why

Rounds out the **live upload tab** so a first-time visitor (paper reader / conference attendee) can use it without their own file and understands what they're seeing. Scoped to the demo app's UX — MCP/REST (#116) and live model-wiring stay deferred.

## Changes

- **Example log** — ships a 0.27 MB six-week slice of the sepsis log (`demo/examples/sepsis_sample.xes`), wired via `gr.Examples` with **no `fn` / `cache_examples=False`** so it never executes at build time. Framed on the page as a stand-in for your own upload, explicitly distinct from the Bundled tab's backtest. Generator committed at `demo/scripts/make_example_log.py` (provenance; not shipped to the Space).
- **Progress** — `run_live` is now a generator that yields an immediate "⏳ Forecasting…" state before the ~120 s ZeroGPU call, so the tab never looks frozen.
- **Onboarding** — a collapsed "What am I looking at?" accordion on each tab (DFG / DF relation / drift-vs-accuracy / ER·MAE·RMSE) plus dropdown and view tooltips.
- **Caps** — a limits caption **derived from `upload_guard`'s `MAX_UPLOAD_BYTES` / `SMALL_LOG_BYTES`**, so the displayed caps match the guard's rejection messages exactly (26.2 MB / 5.2 MB).
- **Deploy** — `deploy-demo.yml` syncs `demo/examples/`; `test_deploy.py` pins the contract.

## Notes

- The live path is **unchanged** (chronos2 only; moirai2/timesfm2.5 still gated). Inference stays mocked in tests as in slices 3a/3b.
- The example forecasts through the **real** live path (`gr.Examples` → upload widget → `run_live` → `_run_live` @spaces.GPU → `forecast_live`), verified end-to-end on CPU in ~23 s; it produces a correct drift bundle with no accuracy metrics.
- Drift on the example is one-sided (+0 added / −35 dropped / =22 stable) — confirmed structural (Chronos never resurrects a recently-zero relation; verified across sepsis + bpi2017, 34 windows), not a window-choice issue.

## Tests

- `82 passed` (with gradio) / `65 passed + 17 skipped` (CI parity, no gradio). Ruff clean.
- New/updated: example wired + under the small-log gate + yields ≥8 active days with a live tail; `run_live` interim→final yields; caps note derived from constants; stand-in framing present; onboarding accordions present; deploy syncs `demo/examples/`.

## Verify

- Local: `uv run --with gradio python demo/app.py` → Live tab → click the example → Forecast.
- On merge, the deploy workflow pushes the new UI + example to the ZeroGPU Space — final HITL check there.