### PR TITLE
feat(demo): live model parity — wire moirai2 + timesfm2.5 into the ZeroGPU path

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -33,9 +33,10 @@ from upload_guard import MAX_UPLOAD_BYTES, SMALL_LOG_BYTES, UploadRejected
 DATASETS: list[str] = ["bpi2017", "bpi2019_1", "sepsis", "hospital_billing"]
 MODELS: list[str] = ["chronos2", "moirai2", "timesfm2.5"]
 
-# The live path runs on ZeroGPU. Only Chronos-2 is wired this slice (#115); moirai2 /
-# timesfm2.5 stay gated (a follow-up), so the live picker offers Chronos-2 alone.
-LIVE_MODELS: list[str] = ["chronos2"]
+# The live path runs on ZeroGPU and now offers all three TSFMs (parity with the bundled
+# tab). The heavy two (moirai2 / timesfm2.5) are gated to small logs by ``upload_guard`` so
+# a single GPU call stays under the ZeroGPU wall-time cap.
+LIVE_MODELS: list[str] = list(MODELS)
 
 # A tiny committed sample (a dense six-week slice of the bundled sepsis log) so the live
 # tab has a one-click "Try an example" — no one needs their own XES to see the path work.
@@ -51,9 +52,10 @@ EXAMPLE_LOG = Path(__file__).resolve().parent / "examples" / "sepsis_sample.xes"
 # module level" guidance relies on the emulation intercepting `.to('cuda')`, which it does
 # for standard transformers/diffusers — but NOT for the autogluon Chronos-2 loader
 # (`BaseChronosPipeline.from_pretrained(device_map="cuda")`), which inits real CUDA in the
-# parent and breaks the fork. So Chronos-2 is loaded lazily INSIDE the @spaces.GPU call
-# (see forecast_live._chronos2_forecast), where a real GPU exists. The weights cache to disk
-# on first download, so later calls are fast.
+# parent and breaks the fork. So *every* model (Chronos-2, Moirai-2, TimesFM-2.5) is loaded
+# lazily INSIDE the @spaces.GPU call (see forecast_live._load_chronos2 / _load_moirai2 /
+# _load_timesfm), where a real GPU exists. The weights cache to disk on first download, so
+# later calls are fast.
 try:
     import spaces
 
@@ -405,7 +407,7 @@ def _build_live_tab() -> None:
             LIVE_MODELS,
             value=LIVE_MODELS[0],
             label="Model",
-            info="Chronos-2 is wired on the hosted GPU; more models are a follow-up",
+            info="All three TSFMs run on the hosted GPU; Moirai-2 / TimesFM are limited to small logs",
         )
         run = gr.Button("Forecast", variant="primary")
     gr.Examples(

--- a/demo/forecast_live.py
+++ b/demo/forecast_live.py
@@ -25,11 +25,22 @@ from dfg_diff import dfg_diff
 from log_to_series import log_to_df_series
 from render import dfg_json_to_svg, diff_svg
 
-# Chronos-2 is the only model wired on the hosted live path this slice (#115);
-# moirai2 / timesfm2.5 stay a documented follow-up. The id matches
-# configs/model/chronos/chronos2.yaml. Loading an ``s3://`` checkpoint needs boto3.
+# All three TSFMs are wired on the hosted live path (model parity with the bundled tab).
+# Each model has its own lazy loader + ``(context, horizon) -> forecast`` adapter below,
+# dispatched by ``_live_windows``. The heavy two (moirai2 / timesfm2.5) are gated to small
+# logs by ``upload_guard`` so a single GPU call stays under the ZeroGPU wall-time cap.
+#
+# Model ids match the paper configs: configs/model/chronos/chronos2.yaml,
+# configs/model/moirai/2_0_small.yaml, configs/model/timesfm/2_5_200m.yaml.
+# Loading the Chronos-2 ``s3://`` checkpoint needs boto3.
 _CHRONOS2_MODEL_ID = "s3://autogluon/chronos-2/"
-_chronos2_pipeline: object | None = None  # cache, loaded once per (forked) worker process
+_MOIRAI2_MODEL_ID = "Salesforce/moirai-2.0-R-small"
+_TIMESFM_MODEL_ID = "google/timesfm-2.5-200m-pytorch"
+# Per-model caches, each loaded once per (forked) worker process. See the ZeroGPU note on
+# _load_chronos2: every loader runs lazily INSIDE the @spaces.GPU worker, never at import.
+_chronos2_pipeline: object | None = None
+_moirai2_module: object | None = None
+_timesfm_model: object | None = None
 
 
 def _load_chronos2() -> object:
@@ -90,6 +101,136 @@ def _chronos2_forecast(context: np.ndarray, horizon: int) -> np.ndarray:
     return forecast
 
 
+def _load_moirai2() -> object:
+    """Load (and cache) the Moirai-2 module. Imports ``uni2ts`` lazily so the live-core
+    module stays importable — and testable — without the model libs.
+
+    Loaded only from inside the ``@spaces.GPU`` worker (via :func:`_moirai2_forecast`),
+    never at module import: ZeroGPU forks a worker per GPU call, and initialising CUDA in
+    the parent process breaks that fork with "process PID not found (pid=0)". The forecast
+    object built per call moves to the GPU that exists inside the worker. The weights cache
+    to disk on first download (~43 MB), so subsequent workers load fast.
+    """
+    global _moirai2_module
+    if _moirai2_module is None:
+        from uni2ts.model.moirai2 import Moirai2Module
+
+        _moirai2_module = Moirai2Module.from_pretrained(_MOIRAI2_MODEL_ID)
+    return _moirai2_module
+
+
+def _moirai2_forecast(context: np.ndarray, horizon: int) -> np.ndarray:
+    """Forecast the next ``horizon`` days of every DF relation with Moirai-2.
+
+    A minimal port of ``pmf_tsfm.models.moirai.MoiraiAdapter`` (the 2.0 path): batch every
+    feature into one GluonTS ``predict`` over a ``ListDataset``, take the median quantile —
+    kept here so the live path needs only ``uni2ts``/``gluonts``, not the full ``pmf_tsfm``
+    dep tree. **This is the GPU work** (wrapped by ``@spaces.GPU`` in the GUI) and is what
+    tests monkeypatch.
+
+    Args:
+        context: ``(n_days, n_features)`` history — the whole log's daily DF series.
+        horizon: number of future days to forecast.
+
+    Returns:
+        ``(horizon, n_features)`` forecast frequencies (median).
+    """
+    from gluonts.dataset.common import ListDataset
+    from uni2ts.model.moirai2 import Moirai2Forecast
+
+    module = _load_moirai2()
+    n_features = context.shape[1]
+    model = Moirai2Forecast(
+        module=module,
+        prediction_length=horizon,
+        context_length=context.shape[0],
+        target_dim=1,
+        feat_dynamic_real_dim=0,
+        past_feat_dynamic_real_dim=0,
+    )
+    predictor = model.create_predictor(batch_size=16)
+    dataset = ListDataset(
+        [{"target": context[:, i].tolist(), "start": "2020-01-01"} for i in range(n_features)],
+        freq="D",
+    )
+    forecasts = list(predictor.predict(dataset))
+    forecast = np.zeros((horizon, n_features))
+    for feat_idx, fc in enumerate(forecasts):
+        forecast[:, feat_idx] = np.asarray(fc.quantile(0.5))[:horizon]
+    return forecast
+
+
+def _load_timesfm() -> object:
+    """Load (and cache) the TimesFM-2.5 model. Imports ``timesfm`` lazily so the live-core
+    module stays importable — and testable — without the model libs.
+
+    Loaded only from inside the ``@spaces.GPU`` worker (via :func:`_timesfm_forecast`),
+    never at module import — same ZeroGPU fork rule as :func:`_load_chronos2`. The forecast
+    config mirrors configs/model/timesfm/2_5_200m.yaml. The weights cache to disk on first
+    download (~882 MB), so subsequent workers load fast.
+    """
+    global _timesfm_model
+    if _timesfm_model is None:
+        import timesfm
+
+        model_cls = timesfm.TimesFM_2p5_200M_torch
+        # huggingface_hub >= 0.24 passes transport kwargs (proxies, resume_download) to
+        # ``_from_pretrained``, which timesfm forwards into ``__init__`` and chokes on. Strip
+        # them for the duration of the load (mirrors pmf_tsfm.models.timesfm's workaround).
+        _orig = model_cls.__dict__.get("_from_pretrained")
+        if _orig is not None:
+            _orig_fn = _orig.__func__
+
+            @classmethod  # type: ignore[misc]
+            def _patched(cls, *, proxies=None, resume_download=None, **kwargs):
+                return _orig_fn(cls, **kwargs)
+
+            model_cls._from_pretrained = _patched
+        try:
+            model = model_cls.from_pretrained(_TIMESFM_MODEL_ID)
+        finally:
+            if _orig is not None:
+                model_cls._from_pretrained = _orig
+        model.compile(
+            timesfm.ForecastConfig(
+                max_context=1024,
+                max_horizon=64,
+                normalize_inputs=True,
+                per_core_batch_size=1,
+                use_continuous_quantile_head=True,
+                force_flip_invariance=True,
+                infer_is_positive=True,
+                fix_quantile_crossing=True,
+            )
+        )
+        _timesfm_model = model
+    return _timesfm_model
+
+
+def _timesfm_forecast(context: np.ndarray, horizon: int) -> np.ndarray:
+    """Forecast the next ``horizon`` days of every DF relation with TimesFM-2.5.
+
+    A minimal port of ``pmf_tsfm.models.timesfm.TimesFMAdapter`` (the 2.5 path): forecast
+    every feature as a univariate series in one ``model.forecast`` call, take the point
+    forecast — kept here so the live path needs only ``timesfm``, not the full ``pmf_tsfm``
+    dep tree. **This is the GPU work** (wrapped by ``@spaces.GPU`` in the GUI) and is what
+    tests monkeypatch.
+
+    Args:
+        context: ``(n_days, n_features)`` history — the whole log's daily DF series.
+        horizon: number of future days to forecast.
+
+    Returns:
+        ``(horizon, n_features)`` forecast frequencies (point forecast).
+    """
+    model = _load_timesfm()
+    n_features = context.shape[1]
+    inputs = [context[:, i].astype(np.float32) for i in range(n_features)]
+    point_forecast, _ = model.forecast(horizon=horizon, inputs=inputs)  # type: ignore[attr-defined]
+    # point_forecast is (n_features, horizon) — transpose to (horizon, n_features).
+    return np.asarray(point_forecast).T[:horizon]
+
+
 def _live_windows(
     log: str | Path, model: str, horizon: int
 ) -> tuple[np.ndarray, np.ndarray, list[str]]:
@@ -102,16 +243,22 @@ def _live_windows(
     days of the log (the recent past the drift is measured against).
 
     The whole daily series is the forecast context; its tail is the last-known window.
-    Tests monkeypatch ``log_to_df_series`` / ``_chronos2_forecast`` to keep real model
-    inference out of CI (as slice 3a kept this whole seam mocked).
+    Tests monkeypatch ``log_to_df_series`` / the per-model ``_*_forecast`` adapters to keep
+    real model inference out of CI (as slice 3a kept this whole seam mocked). The dispatch
+    map is built per call (not at module level) so those monkeypatches take effect.
 
     Raises:
         UploadRejected: the model is not wired on the hosted live path, or the log spans
             too few days to forecast a ``horizon``-day window from history.
     """
-    if model != "chronos2":
+    adapters = {
+        "chronos2": _chronos2_forecast,
+        "moirai2": _moirai2_forecast,
+        "timesfm2.5": _timesfm_forecast,
+    }
+    if model not in adapters:
         raise upload_guard.UploadRejected(
-            f"{model} is not yet available on the hosted live demo; use chronos2."
+            f"{model} is not available on the hosted live demo; choose one of {sorted(adapters)}."
         )
 
     series = log_to_df_series(log)
@@ -124,7 +271,7 @@ def _live_windows(
         )
 
     last_known_window = values[-horizon:]
-    forecast_window = _chronos2_forecast(values, horizon)
+    forecast_window = adapters[model](values, horizon)
     return forecast_window, last_known_window, feature_names
 
 

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -4,9 +4,10 @@
 #   * Bundled explorer — serves precomputed assets incl. pre-rendered SVGs; needs only
 #     gradio. GPU-free, no `dot` binary required for that path.
 #   * Live upload — preprocesses + forecasts an uploaded log on ZeroGPU and renders its
-#     DFGs at request time, so it pulls in graphviz, the model libs (Chronos-2), and the
-#     `spaces` GPU shim. `pmf_tsfm` is deliberately NOT installed — the live path reuses
-#     only the lean, vendored demo modules (dfg_build / log_to_series / forecast_live).
+#     DFGs at request time, so it pulls in graphviz, the three model libs (Chronos-2 +
+#     Moirai-2 + TimesFM-2.5), and the `spaces` GPU shim. `pmf_tsfm` is deliberately NOT
+#     installed — the live path imports the model libs directly and reuses the vendored
+#     demo modules (dfg_build / log_to_series / forecast_live), not the heavy paper package.
 #
 # The gradio pin must match the README frontmatter `sdk_version`. graphviz also needs the
 # system `dot` binary — see packages.txt.
@@ -19,3 +20,9 @@ pm4py>=2.7.12.4
 torch>=2.2
 chronos-forecasting>=1.4.0
 boto3>=1.28  # Chronos-2 loads from an s3:// checkpoint (configs/model/chronos/chronos2.yaml)
+# Moirai-2 (uni2ts) + TimesFM-2.5 for live model parity with the bundled tab. These are the
+# heavy libs (uni2ts drags in jax/jaxlib/gluonts/lightning, ~+490 MB) — gated to small logs
+# by upload_guard so a single GPU call stays under the ZeroGPU wall-time cap.
+uni2ts>=2.0.0
+# Pinned to the same commit as the pyproject `timesfm_v25` extra (no 2.x release tags exist).
+timesfm @ https://github.com/google-research/timesfm/archive/ed29ec5ef7e2d86c48b632859de3b63856ef9cad.zip

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -863,6 +863,15 @@ def test_app_builds_both_tabs():
     assert {"Bundled explorer", "Live upload (your log)"} <= labels
 
 
+def test_live_tab_offers_all_bundled_models():
+    """The live upload tab reaches model parity with the bundled explorer — all three TSFMs
+    are offered, not chronos2 alone (the heavy two are gated to small logs by the guard)."""
+    pytest.importorskip("gradio")
+    import app
+
+    assert app.LIVE_MODELS == app.MODELS == ["chronos2", "moirai2", "timesfm2.5"]
+
+
 def test_run_live_renders_panes_and_drift_on_success(monkeypatch):
     """A successful upload yields the twin panes, both drift overlays, and a drift tally."""
     pytest.importorskip("gradio")

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -30,11 +30,21 @@ DEMO = Path(__file__).resolve().parent.parent
 REPO = DEMO.parent
 WORKFLOW = REPO / ".github" / "workflows" / "deploy-demo.yml"
 
-# The one dep that must never reach the Space: pmf_tsfm (its heavy model/uni2ts/wandb tree).
-# The live path reuses only the lean, vendored demo modules instead (ADR-0005 amended, #115).
+# The one dep that must never reach the Space: pmf_tsfm (the heavy paper package with its
+# wandb/training tree). The live path installs the model libs directly and reuses the
+# vendored demo modules instead (ADR-0005 amended, #115).
 _FORBIDDEN_SERVE_DEPS = ("pmf-tsfm", "pmf_tsfm")
-# The live tab needs these at serve time (ZeroGPU forecast + request-time DFG rendering).
-_REQUIRED_LIVE_DEPS = ("spaces", "graphviz", "torch", "chronos-forecasting", "pm4py")
+# The live tab needs these at serve time (ZeroGPU forecast + request-time DFG rendering):
+# the three model libs (chronos-forecasting / uni2ts / timesfm) + render/GPU shims.
+_REQUIRED_LIVE_DEPS = (
+    "spaces",
+    "graphviz",
+    "torch",
+    "chronos-forecasting",
+    "uni2ts",
+    "timesfm",
+    "pm4py",
+)
 
 
 def _requirement_names(text: str) -> set[str]:

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -156,10 +156,17 @@ def test_example_log_is_a_usable_live_input():
 # --- _live_windows (the seam: preprocess + forecast) ------------------------
 
 
+# A distinct stub constant per model so a dispatch test can confirm each model id routes
+# to *its own* adapter (not just "some forecast came back").
+_STUB_FORECAST = {"chronos2": 9.0, "moirai2": 8.0, "timesfm2.5": 7.0}
+
+
 @pytest.fixture
 def stub_live_seam(monkeypatch):
-    """Stand in for the two halves of the seam: the log→series converter and the
-    Chronos-2 call. A 5-day series over 3 relations; the forecast is a constant 9.0."""
+    """Stand in for the two halves of the seam: the log→series converter and each
+    per-model forecast call. A 5-day series over 3 relations; every model's stub forecasts
+    its own constant (``_STUB_FORECAST``) so dispatch routing is checkable, and CI never
+    loads a real model lib (chronos / uni2ts / timesfm)."""
     import forecast_live
 
     cols = ["▶ -> A", "A -> B", "B -> ■"]
@@ -169,28 +176,35 @@ def stub_live_seam(monkeypatch):
         index=pd.date_range("2020-01-01", periods=5),
     )
     monkeypatch.setattr(forecast_live, "log_to_df_series", lambda log, **k: frame)
-    monkeypatch.setattr(
-        forecast_live,
-        "_chronos2_forecast",
-        lambda context, horizon: np.full((horizon, context.shape[1]), 9.0),
-    )
+    for fn_name, value in (
+        ("_chronos2_forecast", _STUB_FORECAST["chronos2"]),
+        ("_moirai2_forecast", _STUB_FORECAST["moirai2"]),
+        ("_timesfm_forecast", _STUB_FORECAST["timesfm2.5"]),
+    ):
+        monkeypatch.setattr(
+            forecast_live,
+            fn_name,
+            lambda context, horizon, _v=value: np.full((horizon, context.shape[1]), _v),
+        )
     return frame
 
 
-def test_live_windows_forecasts_from_end_and_tails_the_recent_window(tmp_path, stub_live_seam):
+@pytest.mark.parametrize("model", ["chronos2", "moirai2", "timesfm2.5"])
+def test_live_windows_forecasts_from_end_and_tails_the_recent_window(
+    tmp_path, stub_live_seam, model
+):
     """Both windows are ``(horizon, F)`` in one feature space: the forecast from the log
-    end, and the actual last ``horizon`` days (the recent past)."""
+    end, and the actual last ``horizon`` days (the recent past). Each of the three live
+    models routes to its own adapter (the distinct stub constant proves the dispatch)."""
     from forecast_live import _live_windows
 
-    forecast_window, last_known_window, feature_names = _live_windows(
-        tmp_path / "x.xes", "chronos2", 2
-    )
+    forecast_window, last_known_window, feature_names = _live_windows(tmp_path / "x.xes", model, 2)
 
     assert feature_names == list(stub_live_seam.columns)
     assert forecast_window.shape == (2, 3) and last_known_window.shape == (2, 3)
     # last-known = the recent tail of the series; forecast = the model's true-future call.
     np.testing.assert_array_equal(last_known_window, stub_live_seam.to_numpy()[-2:])
-    np.testing.assert_array_equal(forecast_window, np.full((2, 3), 9.0))
+    np.testing.assert_array_equal(forecast_window, np.full((2, 3), _STUB_FORECAST[model]))
 
 
 def test_live_windows_rejects_log_with_too_little_history(tmp_path, monkeypatch):
@@ -205,16 +219,16 @@ def test_live_windows_rejects_log_with_too_little_history(tmp_path, monkeypatch)
         forecast_live._live_windows(tmp_path / "x.xes", "chronos2", 7)
 
 
-def test_live_windows_rejects_unwired_model_before_preprocessing(tmp_path, monkeypatch):
-    """Only chronos2 is wired this slice; a gated model is rejected before any work runs."""
+def test_live_windows_rejects_unknown_model_before_preprocessing(tmp_path, monkeypatch):
+    """All three wired models dispatch; an unknown model id is rejected before any work runs."""
     import forecast_live
 
     def _boom(*a, **k):
-        raise AssertionError("preprocessing ran for an unwired model")
+        raise AssertionError("preprocessing ran for an unknown model")
 
     monkeypatch.setattr(forecast_live, "log_to_df_series", _boom)
-    with pytest.raises(UploadRejected, match="chronos2"):
-        forecast_live._live_windows(tmp_path / "x.xes", "moirai2", 7)
+    with pytest.raises(UploadRejected, match="not available"):
+        forecast_live._live_windows(tmp_path / "x.xes", "gpt5", 7)
 
 
 def test_forecast_live_runs_through_the_real_seam(tmp_path, stub_live_seam):


### PR DESCRIPTION
## What

The live upload tab offered **chronos2 only**; the bundled tab offers all three TSFMs. This brings the live ZeroGPU path to **model parity** — a user can upload a small log and forecast it with chronos2, moirai2, or timesfm2.5, seeing the same drift output. Closes the deferred design item from #121 (PRD #112).

## Changes

- **`forecast_live.py`** — replace the chronos2-only reject in `_live_windows` with a per-call dispatch map; add `_moirai2_forecast`/`_load_moirai2` (uni2ts / Moirai-2) and `_timesfm_forecast`/`_load_timesfm` (TimesFM-2.5). Each loader imports its model lib **inside the function** (never at import) to stay ZeroGPU fork-safe — the `pid=0` CUDA-in-parent trap that bit Chronos-2 in #120. Both mirror `_chronos2_forecast`'s `(context, horizon) -> (horizon, n_features)` contract. Ported the timesfm hub `proxies`-kwarg load workaround from the paper adapter.
- **`app.py`** — `LIVE_MODELS = list(MODELS)`; refreshed the dropdown copy and the no-eager-CUDA comment for all three loaders.
- **`requirements.txt`** — add `uni2ts` + the pinned `timesfm` archive for serve-time live inference. Build-size probe: **+490 MB (+56%)**, almost entirely `uni2ts` (it pulls `jaxlib` 228 MB + jax/gluonts/lightning); `timesfm` is ~+4 MB on top. Still never installs `pmf_tsfm`.
- **tests** — dispatch parametrized across all three models; unwired-reject test replaced with an unknown-model test; live-tab parity assertion added; `_REQUIRED_LIVE_DEPS` extended with `uni2ts` + `timesfm`.

## Gating & safety

- The heavy two stay **gated to small logs** by `upload_guard` (`GATED_MODELS`, < 5 MB) so a single GPU call stays under the ZeroGPU wall-time cap. The example `sepsis_sample.xes` (0.27 MB) works with all three.
- `pmf_tsfm`-free serve invariant preserved (`test_deploy` enforces `_FORBIDDEN_SERVE_DEPS`).

## Verification

- CI parity (no gradio): **67 passed / 18 skipped**; full (gradio): **85 passed**; `test_deploy` **5/5**; ruff clean.
- **Local CPU check** against the real cached weights: both new adapters returned correct finite `(horizon, n_features)` forecasts.
- **Pending after merge (HITL):** deploy auto-triggers; verify moirai2 then timesfm2.5 on the live tab with the example log — confirm each forecasts + renders drift on the ZeroGPU Space. First call per model is slow (cold weight download).