### PR TITLE
docs(demo): live tab is Chronos-2 only by design — drop 'more models coming'

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -34,8 +34,9 @@ process evolve over time.
 **Live upload (your log).** Upload a custom **XES** log and forecast its genuine next week (forecast
 origin = the log end) on **ZeroGPU**. Because an upload has no future ground truth, this tab reports
 **drift** — the DF relations the forecast adds or drops vs the **last-known window** — and **never**
-an accuracy metric (ADR-0004). Default **Chronos-2**; oversize logs and heavy models are capped so a
-call stays under the GPU time limit.
+an accuracy metric (ADR-0004). Live forecasts run with **Chronos-2** (Moirai-2 and TimesFM-2.5 are
+available in the Bundled explorer tab); oversize logs are rejected so a call stays under the GPU
+time limit.
 
 ## How it runs
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -33,8 +33,10 @@ from upload_guard import MAX_UPLOAD_BYTES, SMALL_LOG_BYTES, UploadRejected
 DATASETS: list[str] = ["bpi2017", "bpi2019_1", "sepsis", "hospital_billing"]
 MODELS: list[str] = ["chronos2", "moirai2", "timesfm2.5"]
 
-# The live path runs on ZeroGPU. Only Chronos-2 is wired this slice (#115); moirai2 /
-# timesfm2.5 stay gated (a follow-up), so the live picker offers Chronos-2 alone.
+# The live path runs on ZeroGPU and offers Chronos-2 only — by design, not a stopgap.
+# Moirai-2 / TimesFM-2.5 stay in the Bundled explorer tab: uni2ts pins numpy~=1.26, which
+# breaks the numpy-2.x Chronos/torch ZeroGPU stack on the shared Space (live parity was
+# attempted in #122, reverted in #123). The upload guard still recognises them as gated.
 LIVE_MODELS: list[str] = ["chronos2"]
 
 # A tiny committed sample (a dense six-week slice of the bundled sepsis log) so the live
@@ -405,7 +407,7 @@ def _build_live_tab() -> None:
             LIVE_MODELS,
             value=LIVE_MODELS[0],
             label="Model",
-            info="Chronos-2 is wired on the hosted GPU; more models are a follow-up",
+            info="Forecasts run with Chronos-2 on the hosted GPU; Moirai-2 / TimesFM-2.5 live in the Bundled explorer tab",
         )
         run = gr.Button("Forecast", variant="primary")
     gr.Examples(


### PR DESCRIPTION
## Why

Final-delivery polish. After reverting live model parity (#123), the live-tab dropdown copy and the README still implied moirai2/timesfm2.5 were a coming follow-up on the **live** path. They're not — the live tab offers **Chronos-2 only by design**, because `uni2ts` pins `numpy~=1.26`, which is incompatible with the numpy-2.x Chronos/torch ZeroGPU stack on the shared Space (attempted #122, reverted #123). Moirai-2 / TimesFM-2.5 remain fully available in the **Bundled explorer** tab.

## Changes (copy only, no behaviour change)

- `app.py` — live-tab dropdown `info=` and the `LIVE_MODELS` comment now state Chronos-2 is the live model by design, and point users to the Bundled tab for the other two.
- `README.md` — live-upload paragraph clarified to match (no longer implies the heavy models are selectable-but-capped on the live tab).

## Verification

Full suite (gradio): **82 passed**; ruff clean. No code/behaviour change — README frontmatter (gradio `sdk_version`) untouched, so the Space build is unaffected.