### PR TITLE
fix(slides): lock colorSchema to light

### DIFF
--- a/slides/template/slides.md
+++ b/slides/template/slides.md
@@ -1,5 +1,6 @@
 ---
 theme: default
+colorSchema: light
 title: Time Series Foundation Models for Process Model Forecasting
 info: |
   CAiSE 2026 presentation — pmf-tsfm


### PR DESCRIPTION
One-line headmatter fix: pin `colorSchema: light` so the deck renders deterministically light on any machine (it previously followed the viewer's OS preference, which broke contrast for the ink-on-white figures and the assertion-evidence / center layouts on dark-mode machines).

Closes #76. The issue's second item (consolidate the `DfgEvolution` color palette) is obsolete — `DfgEvolution` is orphaned and unused after the v2 rebuild; the palette is already single-sourced (`palette.json` → `style.css` → `figure_manifest.py`, #107).