### PR TITLE
docs(demo): live-tab honesty + comparison-DFG clarity copy polish

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -34,7 +34,7 @@ process evolve over time.
 **Live upload (your log).** Upload a custom **XES** log and forecast its genuine next week (forecast
 origin = the log end) on **ZeroGPU**. Because an upload has no future ground truth, this tab reports
 **drift** — the DF relations the forecast adds or drops vs the **last-known window** — and **never**
-an accuracy metric (ADR-0004). Live forecasts run with **Chronos-2** (Moirai-2 and TimesFM-2.5 are
+an accuracy metric. Live forecasts run with **Chronos-2** (Moirai-2 and TimesFM-2.5 are
 available in the Bundled explorer tab); oversize logs are rejected so a call stays under the GPU
 time limit.
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -27,7 +27,7 @@ from typing import Any
 import gradio as gr
 from forecast import forecast_bundled
 from forecast_live import forecast_live
-from upload_guard import MAX_UPLOAD_BYTES, SMALL_LOG_BYTES, UploadRejected
+from upload_guard import MAX_UPLOAD_BYTES, UploadRejected
 
 # Only the precomputed bundled pairs are offered as choices: the full 4-by-3 matrix.
 DATASETS: list[str] = ["bpi2017", "bpi2019_1", "sepsis", "hospital_billing"]
@@ -285,9 +285,8 @@ def _live_caps_note() -> str:
     displayed caps can never drift from what ``upload_guard.check_upload`` actually enforces.
     """
     return (
-        f"**Limits** — max upload **{MAX_UPLOAD_BYTES / 1e6:.1f} MB**. Chronos-2 forecasts any "
-        f"log up to that cap; Moirai-2 / TimesFM-2.5 (when enabled) are limited to logs under "
-        f"**{SMALL_LOG_BYTES / 1e6:.1f} MB** so a single call stays within the GPU time limit."
+        f"**Limits** — max upload **{MAX_UPLOAD_BYTES / 1e6:.1f} MB**; "
+        f"Chronos-2 forecasts any log up to that cap."
     )
 
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -217,7 +217,7 @@ def _drift_summary(drift: dict[str, list[dict[str, Any]]]) -> str:
         f"{len(drift['removed'])} it **drops**, "
         f"{len(drift['stable'])} unchanged. "
         "_This is change from the recent past, not accuracy — an upload has no future "
-        "truth to score against (ADR-0004)._"
+        "truth to score against._"
     )
 
 
@@ -297,9 +297,10 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
     initial render happens once the Blocks context is open).
     """
     gr.Markdown(
-        "Holdout backtest (ADR-0004): the real last week is **held out** and forecast "
-        "from the rest, then compared against what actually happened — so ER / MAE / RMSE "
-        "are genuine accuracy."
+        "The real last week is **held out** and forecast from the rest, then scored "
+        "against what actually happened. The right-hand graph is that **same-period "
+        "actual week** — the held-out **ground truth** — so ER / MAE / RMSE are genuine "
+        "accuracy."
     )
     with gr.Accordion("What am I looking at?", open=False):
         gr.Markdown(
@@ -307,7 +308,8 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
             "**directly-follows (DF) relation** (b directly follows a), the number on it the "
             "count over the week.\n\n"
             "- **Forecast** — the held-out last week, as the model predicted it from prior weeks.\n"
-            "- **Actual future** — what really happened that week.\n"
+            "- **Actual future** — the real **same-period** week, held out as **ground truth** "
+            "for scoring (contrast the Live tab, where the comparison is the recent *past*).\n"
             "- **ER / MAE / RMSE** — how accurate the forecast was against that actual future. "
             "**Entropic Relevance (ER)** scores how well a DFG explains the real behaviour "
             "(lower is better; the *truth (baseline)* box is the ER of the actual DFG itself — the "
@@ -334,7 +336,7 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
             gr.Markdown("### Forecast — the held-out last week, predicted")
             forecast_pane = gr.HTML(elem_classes=["dfg-pane"])
         with gr.Column():
-            gr.Markdown("### Actual future — what really happened that week")
+            gr.Markdown("### Actual future — the same week's real DFG (held-out ground truth)")
             actual_pane = gr.HTML(elem_classes=["dfg-pane"])
     with gr.Column(visible=False) as diff_overlay:
         gr.Markdown("### Diff — forecast vs actual future")
@@ -383,10 +385,11 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
 def _build_live_tab() -> None:
     """The live upload tab (slice 3b): upload → ZeroGPU forecast → drift view."""
     gr.Markdown(
-        "Upload a custom **XES** log to forecast its genuine next week (forecast origin = "
-        "the log end) on ZeroGPU, then read the **drift** of that forecast vs the "
-        "**last-known window** — DF relations the forecast adds or drops. There is no "
-        "future truth for an upload, so this path shows **drift, never accuracy** (ADR-0004)."
+        "Upload a custom **XES** log to forecast its **genuine next week** (forecast origin "
+        "= the log end) on ZeroGPU. The right-hand graph is **not** a future truth — it is "
+        "your log's **last-known window** (its recent *past*) — so the comparison is **drift** "
+        "(DF relations the forecast adds or drops), **never accuracy**. (Contrast the Bundled "
+        "tab, where the right-hand graph is the real same-period week.)"
     )
     with gr.Accordion("What am I looking at?", open=False):
         gr.Markdown(
@@ -398,7 +401,7 @@ def _build_live_tab() -> None:
             "- **Last-known window** — the most recent week already in your log.\n"
             "- **Drift** — the DF relations the forecast **adds** or **drops** vs that recent past.\n\n"
             "No accuracy metric (ER / MAE / RMSE) is shown: an upload has no future ground truth to "
-            "score against (ADR-0004). For scored accuracy, see the **Bundled explorer** tab."
+            "score against. For scored accuracy, see the **Bundled explorer** tab."
         )
     with gr.Row():
         upload = gr.File(label="XES event log", file_types=[".xes"], type="filepath")
@@ -406,7 +409,7 @@ def _build_live_tab() -> None:
             LIVE_MODELS,
             value=LIVE_MODELS[0],
             label="Model",
-            info="Forecasts run with Chronos-2 on the hosted GPU; Moirai-2 / TimesFM-2.5 live in the Bundled explorer tab",
+            info="Forecasts run with Chronos-2 on the hosted GPU",
         )
         run = gr.Button("Forecast", variant="primary")
     gr.Examples(
@@ -431,7 +434,9 @@ def _build_live_tab() -> None:
             gr.Markdown("### Forecast — the genuine next week, predicted")
             forecast_pane = gr.HTML(elem_classes=["dfg-pane"])
         with gr.Column():
-            gr.Markdown("### Last-known window — the recent past it is compared against")
+            gr.Markdown(
+                "### Last-known window — your log's recent past (drift baseline, *not* a future truth)"
+            )
             comparison_pane = gr.HTML(elem_classes=["dfg-pane"])
     with gr.Column(visible=False) as drift_overlay:
         gr.Markdown("### Drift — forecast vs the last-known window")

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -974,9 +974,10 @@ def test_live_caps_note_is_derived_from_guard_constants():
 
     note = app._live_caps_note()
     # Same formatting the guard uses in its rejection messages, so the up-front cap is the
-    # exact number a user sees if their upload is refused (upload_guard.py).
+    # exact number a user sees if their upload is refused (upload_guard.py). The live tab is
+    # Chronos-2 only, so the note shows just that one cap (the gated small-log threshold
+    # applies only to the bundled families, which the live picker never offers).
     assert f"{MAX_UPLOAD_BYTES / 1e6:.1f}" in note
-    assert f"{SMALL_LOG_BYTES / 1e6:.1f}" in note
 
     markdowns = _markdown_values(app.build())
     assert any(note in m for m in markdowns), "caps note must be shown on the live tab"


### PR DESCRIPTION
Final-delivery copy polish on the demo app (no behaviour change, no new deps). All from the v0.1.0 verification/UX pass on the running Space.

## What changed

**1. Live caps note is Chronos-2 only.** The live tab offers Chronos-2 only by design (`LIVE_MODELS = ["chronos2"]`), so the caps note's "Moirai-2 / TimesFM-2.5 (when enabled) are limited to logs under N MB" was dead UI text implying those models were coming to the live path. It now states just the Chronos-2 upload cap. Drops the now-unused `SMALL_LOG_BYTES` import in `app.py` and the coupled assertion in `test_demo.py` (the gated small-log threshold is enforced only for the bundled families, which the live picker never offers).

**2. No internal ADR refs in the UI.** Removed the `ADR-000x` citations leaking into user-facing text (bundled intro "Holdout backtest (ADR-0004)", live intro/accordion, drift summary, README live blurb). ADR pointers stay in the source docstrings/comments, not the rendered app.

**3. Trimmed the live model picker caption.** Dropped the Moirai-2 / TimesFM-2.5 mention from the live dropdown caption — noise on a Chronos-2-only tab.

**4. Clarified the comparison-DFG contrast** (the point users most often confuse): the right-hand DFG means different things across the two tabs.
- **Bundled** — the real **same-period** week, held out as **ground truth** (so accuracy is scored).
- **Live** — the log's **last-known window** (recent *past*), a **drift baseline**, *not* a future truth.

Sharpened both intros, the accordion bullets, and the twin-pane titles, with an explicit cross-reference each way.

## Verification
- `uv run pytest demo/tests/` → 65 passed, 17 skipped.
- `uv run --with gradio pytest demo/tests/` → 82 passed.
- `ruff check` + `ruff format --check` clean.
- Headless render asserts: no ADR strings in rendered markdown, Chronos-2-only caps note + picker caption, both ground-truth/recent-past phrasings present with the cross-reference.
- Live forecast confirmed working on the Space with the bundled sepsis example (Chronos-2 on ZeroGPU).