### PR TITLE
feat(demo): self-host Docker image (MVP GUI-only)

### DIFF
--- a/demo/.dockerignore
+++ b/demo/.dockerignore
@@ -1,0 +1,26 @@
+# Build context is demo/. Keep what the image needs at runtime:
+#   assets/    pre-rendered SVGs + metrics the Bundled tab serves
+#   examples/  sepsis_sample.xes — the Live tab's one-click example
+#   static/    vendored svg-pan-zoom.min.js
+#   README.md  copied for in-image reference
+# Everything below is dev-only or regenerable and is excluded.
+
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+
+# Dev-only: tests + helper scripts aren't served by the app.
+tests/
+scripts/
+
+# Agent handoffs (dated markdown) — never part of the image.
+HANDOFF_*.md
+
+# Containerisation files themselves.
+Dockerfile
+.dockerignore
+
+# Local caches / virtualenvs that must never leak into the build.
+.venv/
+.cache/

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,51 @@
+# Self-host Docker image for the Process Model Forecasting explorer (ADR-0003 amendment,
+# "one codebase, two packagings"). The hosted runtime stays a Gradio-SDK HF Space; this is
+# the SECOND packaging — a self-host image (GUI by default) for talk-recording and for
+# others running the demo on their own logs/hardware with no HF caps and no ZeroGPU
+# cold-start. Built from the SAME demo/ code.
+#
+#   Build:  docker build -t pmf-tsfm-demo demo/
+#   Run:    docker run -p 7860:7860 pmf-tsfm-demo
+#   Open:   http://localhost:7860
+#
+# The live tab runs on plain CPU here: there is no `spaces` package in the image, so the
+# @spaces.GPU decorator in app.py no-ops (app.py:59-66) and the same code runs without
+# ZeroGPU. The first live forecast downloads the Chronos-2 weights from
+# s3://autogluon/chronos-2/ (one-off, a few minutes on a cold cache). To persist that cache
+# across container runs, mount a volume at HF_HOME:
+#
+#   docker run -p 7860:7860 -v pmf-hf-cache:/app/.cache/huggingface pmf-tsfm-demo
+#
+# This is the MVP GUI-only target (issue #129): the Hydra research CLI (src/pmf_tsfm/) is
+# NOT installed — that is the future full-image target (build context = repo root).
+
+FROM python:3.11-slim
+
+# graphviz provides the `dot` binary the live path needs to render DFGs (mirrors
+# demo/packages.txt). The bundled tab serves pre-rendered SVGs and needs none of this.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install the serve-time deps, but NOT `spaces`: ZeroGPU is HF-only and its absence makes
+# the live forecast fall back to CPU (see header). Filtering keeps requirements.txt the
+# single source of truth rather than forking a docker-specific copy.
+COPY requirements.txt ./requirements.txt
+RUN grep -v '^spaces' requirements.txt > /tmp/requirements.docker.txt \
+    && pip install --no-cache-dir -r /tmp/requirements.docker.txt
+
+# app.py uses flat imports (`from forecast import ...`), so the demo/ files sit at WORKDIR.
+COPY . /app
+
+# Gradio binds to 127.0.0.1 by default, unreachable from outside the container. These env
+# vars make app.py's `demo.launch()` serve on all interfaces without any code change (keeps
+# main() un-forked so the future MCP slice's mcp_server=True flows straight through).
+ENV GRADIO_SERVER_NAME=0.0.0.0 \
+    GRADIO_SERVER_PORT=7860 \
+    HF_HOME=/app/.cache/huggingface
+
+EXPOSE 7860
+
+CMD ["python", "app.py"]

--- a/demo/README.md
+++ b/demo/README.md
@@ -51,3 +51,24 @@ Run it locally:
 ```bash
 uv run --with gradio python app.py
 ```
+
+## Self-host with Docker
+
+The same `demo/` code also ships as a self-host image (ADR-0003, "one codebase, two packagings") —
+the GUI by default, with **no HF upload caps and no ZeroGPU cold-start**. Build the context from the
+repo root so it picks up `demo/`:
+
+```bash
+docker build -t pmf-tsfm-demo demo/
+docker run -p 7860:7860 pmf-tsfm-demo
+```
+
+Then open <http://localhost:7860>. The bundled tab is instant (precomputed assets). The live tab runs
+on **plain CPU** here — the image omits the `spaces` package, so the ZeroGPU decorator no-ops and the
+same forecast runs without a GPU (slower, but no wall-time limit). The **first** live forecast
+downloads the Chronos-2 weights from `s3://autogluon/chronos-2/` (one-off, a few minutes). Persist
+that cache across runs with a volume:
+
+```bash
+docker run -p 7860:7860 -v pmf-hf-cache:/app/.cache/huggingface pmf-tsfm-demo
+```

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -14,7 +14,9 @@ gradio==6.16.0
 spaces>=0.30
 graphviz>=0.20
 numpy>=1.24
-pandas>=2.2.3
+pandas>=2.2.3,<3  # pm4py's pandas backend isn't pandas-3 ready: pandas 3's pyarrow-backed
+                 # string columns break pm4py variant filtering ("is_in has no kernel for
+                 # list<string>"), which the live path hits during preprocessing.
 pm4py>=2.7.12.4
 torch>=2.2
 chronos-forecasting>=1.4.0


### PR DESCRIPTION
Packages the demo as a **self-host Docker image** per the ADR-0003 amendment's *second packaging* — the GUI by default, the live forecast on plain **CPU** with **no HF caps and no ZeroGPU cold-start** (the talk-recording build). Scope is **MVP GUI-only**; the Hydra research CLI is the future full-image target.

## What's in the image
- `python:3.11-slim` + apt `graphviz` (the `dot` binary the live path needs).
- Installs `requirements.txt` **minus `spaces`** (filtered with `grep -v`, so `requirements.txt` stays the single source of truth). With no `spaces` package, `app.py`'s `@spaces.GPU` falls back to a no-op and the live forecast runs on CPU — no ZeroGPU.
- `GRADIO_SERVER_NAME=0.0.0.0` so `main()` serves externally with **no app-code change** (keeps `main()` un-forked, so the future MCP slice's `mcp_server=True` flows straight through).
- `HF_HOME=/app/.cache/huggingface` so a `-v` mount can persist the Chronos-2 weights between runs.

```
docker build -t pmf-tsfm-demo demo/
docker run -p 7860:7860 pmf-tsfm-demo   # → http://localhost:7860
```

## pandas pin (root-cause fix beyond packaging)
A clean `pip install` of the unpinned `requirements.txt` resolves **pandas 3.0**, whose pyarrow-backed string columns break pm4py variant filtering (`is_in has no kernel for list<string>`) — the live path crashes during preprocessing, before the model loads. Pinned `pandas>=2.2.3,<3`, which fixes the image **and** protects the HF Space on its next rebuild (currently latently at risk).

## Files (all under `demo/`)
- **new** `demo/Dockerfile`, `demo/.dockerignore`
- `demo/README.md` — adds a "Self-host with Docker" section (frontmatter untouched)
- `demo/requirements.txt` — `pandas>=2.2.3` → `pandas>=2.2.3,<3`

## Verification (native proxy — Docker not installed on the build machine)
- `grep -v '^spaces'` removes only `spaces>=0.30`.
- GUI builds with `spaces` absent → `_gpu` no-op confirmed; `build()` returns a `Blocks`.
- Bundled path: `forecast_bundled('sepsis','chronos2')` emits all SVGs.
- **Live path on CPU** (the talk artifact): `forecast_live('examples/sepsis_sample.xes','chronos2')` → `cuda: False`, full forecast/comparison/diff SVGs + drift dict. ✅
- `uv run pytest demo/tests/` → **65 passed, 17 skipped** (matches baseline).

Real `docker build`/`docker run` to be exercised where Docker is available.

## Follow-up (next round)
- Relax the upload-guard caps for the self-host image (no host GPU wall-time limit) — flagged by the maintainer, intentionally out of this pure-packaging slice.

Closes #129