### PR TITLE
feat(demo): expose REST + MCP agent surface (forecast_from_source) (#116)

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -44,12 +44,12 @@ The **bundled** path is served from **precomputed, committed assets** (incl. pre
 it is instant, infinitely concurrent, needs **no GPU**, and cannot be DoS'd into a bill. The **live**
 path runs preprocessing + a Chronos-2 forecast under `@spaces.GPU` on **ZeroGPU** and renders its
 DFGs at request time (so the Space carries graphviz + the model libs; see `packages.txt` /
-`requirements.txt`). The REST/MCP surface is a later slice of the same app.
+`requirements.txt`).
 
 Run it locally:
 
 ```bash
-uv run --with gradio python app.py
+uv run --with 'gradio[mcp]' python app.py
 ```
 
 ## Self-host with Docker
@@ -72,3 +72,27 @@ that cache across runs with a volume:
 ```bash
 docker run -p 7860:7860 -v pmf-hf-cache:/app/.cache/huggingface pmf-tsfm-demo
 ```
+
+## Agent API (REST + MCP)
+
+The same app launches with `mcp_server=True`, so beyond the GUI it serves an auto-generated **REST
+API** and an **MCP server** (endpoint `…/gradio_api/mcp/sse`). Exactly **one** tool is exposed — the
+live forecast — and its schema is derived from the function's type hints + docstring (no hand-written
+schema). The bundled accuracy path is **GUI-only** and never reachable as a tool.
+
+**`forecast_from_source(source, model="chronos2")`** — `source` is an `http(s)` URL to an XES log, or
+the keyword `"example"` (the bundled sepsis sample). It returns a **drift** bundle
+(`forecast_dfg`, `comparison_dfg`, `drift`) — DF relations the forecast adds/drops vs the log's
+last-known window — and **never** an accuracy metric (an upload has no future truth).
+
+Call it over REST with `gradio_client`:
+
+```python
+from gradio_client import Client
+
+client = Client("http://127.0.0.1:7860")  # or the Space URL
+bundle = client.predict("example", "chronos2", api_name="/forecast_from_source")
+print(bundle["drift"])  # {"added": [...], "removed": [...], "stable": [...]}
+```
+
+or point any MCP client at `…/gradio_api/mcp/sse` and call the `forecast_from_source` tool.

--- a/demo/app.py
+++ b/demo/app.py
@@ -13,9 +13,12 @@ Two tabs over the two agent-clean deep modules:
   at request time, so this path needs the ``dot`` binary + the model libs (unlike the
   GPU-free bundled path) — see ``requirements.txt`` / ``packages.txt``.
 
-``mcp_server`` stays off in this slice (flipped on in #116, ADR-0003).
+Launched with ``mcp_server=True`` (#116, ADR-0003), the one app serves three surfaces: the
+GUI, an auto-generated REST API, and an MCP server. Only ``forecast_from_source`` (the live
+forecast, by URL/keyword) is a public endpoint → the single agent tool; every GUI listener is
+``api_visibility="private"`` so the bundled accuracy path never leaks to an agent.
 
-    uv run --with gradio python demo/app.py
+    uv run --with 'gradio[mcp]' python demo/app.py
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ from typing import Any
 
 import gradio as gr
 from forecast import forecast_bundled
-from forecast_live import forecast_live
+from forecast_live import EXAMPLE_LOG, forecast_live, resolve_source
 from upload_guard import MAX_UPLOAD_BYTES, UploadRejected
 
 # Only the precomputed bundled pairs are offered as choices: the full 4-by-3 matrix.
@@ -39,9 +42,9 @@ MODELS: list[str] = ["chronos2", "moirai2", "timesfm2.5"]
 # attempted in #122, reverted in #123). The upload guard still recognises them as gated.
 LIVE_MODELS: list[str] = ["chronos2"]
 
-# A tiny committed sample (a dense six-week slice of the bundled sepsis log) so the live
-# tab has a one-click "Try an example" — no one needs their own XES to see the path work.
-EXAMPLE_LOG = Path(__file__).resolve().parent / "examples" / "sepsis_sample.xes"
+# The committed sample (a dense six-week slice of the bundled sepsis log) is the live tab's
+# one-click "Try an example" *and* the agent tool's "example" keyword — defined once in
+# forecast_live (gradio-free) and re-exported here.
 
 # ZeroGPU boundary: ``@spaces.GPU`` requests a GPU slice for the ~120s of the live call
 # (ADR-0001). ``spaces`` only exists on the HF Space, so off-Space (local / CI) we fall
@@ -71,9 +74,48 @@ def _run_live(log_path: str, model: str) -> dict[str, Any]:
     """Run the live forecast under the ZeroGPU slice — the GPU entry point.
 
     A thin wrapper so the GPU boundary sits at the GUI layer; ``forecast_live`` stays
-    agent-clean (no ``spaces`` dependency) for the future MCP/REST tool (#116).
+    agent-clean (no ``spaces`` dependency) for the MCP/REST tool (#116), which reaches the
+    same GPU seam through :func:`forecast_from_source`.
     """
     return forecast_live(log_path, model)
+
+
+# The slim agent payload: the regenerable DFG sources of truth + the drift partition. The
+# pre-rendered SVGs the GUI needs are dropped (agents rarely want rendered figures), and no
+# accuracy metric is ever present — an upload has no future truth (ADR-0004).
+_AGENT_BUNDLE_KEYS = ("forecast_dfg", "comparison_dfg", "drift")
+
+
+def forecast_from_source(source: str, model: str = "chronos2") -> dict[str, Any]:
+    """Forecast an event log's genuine next week and report its drift (never accuracy).
+
+    The agent-facing entry point exposed as the REST/MCP tool (#116). Unlike the GUI it
+    takes a *source string*, not a browser upload: an event log named by URL or keyword is
+    resolved to a local XES file, forecast on the hosted GPU, and summarised as **drift**
+    of the forecast vs the log's last-known window. An upload has no future truth, so this
+    returns drift — DF relations the forecast adds or drops — and **never** an accuracy
+    score. (Scored bundled accuracy is a GUI-only concern; this tool never serves it.)
+
+    Args:
+        source: An ``http(s)`` URL to an XES event log, or the keyword ``"example"`` for the
+                bundled sepsis sample (a zero-setup input). Bundled dataset names are not
+                accepted here — explore those, with accuracy, in the GUI's Bundled tab.
+        model:  Time-series foundation model id. Only ``"chronos2"`` is wired on the hosted
+                live path; other ids are rejected.
+
+    Returns:
+        A drift bundle ``{"forecast_dfg": <dfg json>, "comparison_dfg": <dfg json>,
+        "drift": {"added": [...], "removed": [...], "stable": [...]}}`` — the forecast DFG,
+        the last-known-window DFG it is compared against, and their drift partition (each
+        entry ``{"from", "to", "forecast_freq", "recent_freq"}``). No accuracy metric.
+
+    Raises:
+        UploadRejected: the source can't be resolved (not a URL or known keyword), the
+            downloaded log is too large, or the model is not available on the live path.
+    """
+    path = resolve_source(source)  # GPU-free: download a URL or map the keyword to a path
+    bundle = _run_live(path, model)  # the existing @spaces.GPU seam (same as the GUI)
+    return {key: bundle[key] for key in _AGENT_BUNDLE_KEYS}
 
 
 # Vendored (not CDN) so the Hugging Face Space works fully offline / behind
@@ -365,20 +407,24 @@ def _build_bundled_tab() -> tuple[Any, list[Any], list[Any]]:
         return (*_render_panes(result), *_render_diff(result))
 
     all_outputs = [*outputs, diff_abs_pane, diff_rel_pane]
+    # All GUI listeners are api_visibility="private" so they never become MCP/REST tools:
+    # only forecast_from_source is public (the bundled accuracy path stays GUI-only, #116).
     for picker in inputs:
-        picker.change(refresh, inputs, all_outputs)
+        picker.change(refresh, inputs, all_outputs, api_visibility="private")
 
     def set_view(view: str) -> tuple[Any, Any]:
         is_diff = view == "Diff"
         return gr.update(visible=not is_diff), gr.update(visible=is_diff)
 
-    view.change(set_view, view, [twin_panes, diff_overlay])
+    view.change(set_view, view, [twin_panes, diff_overlay], api_visibility="private")
 
     def set_diff_mode(mode: str) -> tuple[Any, Any]:
         is_rel = mode == "Relative"
         return gr.update(visible=not is_rel), gr.update(visible=is_rel)
 
-    diff_mode.change(set_diff_mode, diff_mode, [diff_abs_row, diff_rel_row])
+    diff_mode.change(
+        set_diff_mode, diff_mode, [diff_abs_row, diff_rel_row], api_visibility="private"
+    )
     return refresh, inputs, all_outputs
 
 
@@ -452,23 +498,28 @@ def _build_live_tab() -> None:
             diff_rel_pane = gr.HTML(elem_classes=["dfg-pane"])
     drift_summary = gr.Markdown()
 
+    # Private like every GUI listener (the agent surface is forecast_from_source alone, #116):
+    # the browser-upload run_live has no agent equivalent anyway — MCP can't drive a file picker.
     run.click(
         run_live,
         [upload, live_model],
         [status, forecast_pane, comparison_pane, diff_abs_pane, diff_rel_pane, drift_summary],
+        api_visibility="private",
     )
 
     def set_view(view: str) -> tuple[Any, Any]:
         is_drift = view == "Drift"
         return gr.update(visible=not is_drift), gr.update(visible=is_drift)
 
-    view.change(set_view, view, [twin_panes, drift_overlay])
+    view.change(set_view, view, [twin_panes, drift_overlay], api_visibility="private")
 
     def set_drift_mode(mode: str) -> tuple[Any, Any]:
         is_rel = mode == "Relative"
         return gr.update(visible=not is_rel), gr.update(visible=is_rel)
 
-    drift_mode.change(set_drift_mode, drift_mode, [diff_abs_row, diff_rel_row])
+    drift_mode.change(
+        set_drift_mode, drift_mode, [diff_abs_row, diff_rel_row], api_visibility="private"
+    )
 
 
 def build() -> gr.Blocks:
@@ -486,9 +537,14 @@ def build() -> gr.Blocks:
             with gr.Tab("Live upload (your log)"):
                 _build_live_tab()
 
-        # Render the bundled tab once on load (the live tab waits for an upload).
+        # The one public API endpoint → the one MCP tool (its type hints + docstring are the
+        # auto-derived schema, ADR-0003). Everything else above is api_visibility="private".
+        gr.api(forecast_from_source, api_name="forecast_from_source")
+
+        # Render the bundled tab once on load (the live tab waits for an upload). Private so
+        # the load hook doesn't surface as a tool.
         refresh, inputs, all_outputs = load_target
-        demo.load(refresh, inputs, all_outputs)
+        demo.load(refresh, inputs, all_outputs, api_visibility="private")
 
     # Gradio 6 takes `head` at launch() (not the Blocks constructor); stash it on
     # the Blocks so callers (main, tests, drivers) pass the same inlined payload.
@@ -498,7 +554,11 @@ def build() -> gr.Blocks:
 
 def main() -> None:
     demo = build()
-    demo.launch(head=demo.demo_head)
+    # mcp_server=True serves the GUI, the REST API (gradio_client), and the MCP endpoint
+    # (/gradio_api/mcp/sse) from this one app — three surfaces, one codebase (ADR-0003).
+    # show_error surfaces the agent tool's clear UploadRejected reason ("use a URL or
+    # 'example'") to REST/MCP callers; without it Gradio hides it behind a generic message.
+    demo.launch(head=demo.demo_head, mcp_server=True, show_error=True)
 
 
 if __name__ == "__main__":

--- a/demo/forecast_live.py
+++ b/demo/forecast_live.py
@@ -15,8 +15,12 @@ are GPU-free and tested in isolation.
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import urlopen
 
 import numpy as np
 import upload_guard
@@ -24,6 +28,13 @@ from dfg_build import frequencies_to_dfg_json
 from dfg_diff import dfg_diff
 from log_to_series import log_to_df_series
 from render import dfg_json_to_svg, diff_svg
+
+# The agent-facing tool (#116) can't drive a browser file picker, so it takes a *source
+# string* the GUI upload widget has no equivalent of. The committed sample (also the live
+# tab's one-click example) doubles as a zero-setup input keyword for that tool.
+EXAMPLE_LOG = Path(__file__).resolve().parent / "examples" / "sepsis_sample.xes"
+_EXAMPLE_ALIASES = frozenset({"example", "sepsis_sample"})
+_DOWNLOAD_CHUNK = 1 << 16  # 64 KiB streamed reads, so the size cap trips before a full buffer
 
 # Chronos-2 is the only model wired on the hosted live path this slice (#115);
 # moirai2 / timesfm2.5 stay a documented follow-up. The id matches
@@ -165,6 +176,68 @@ def drift_report(
         "removed": [entry(e) for e in diff["added"]],  # in recent past, not in forecast
         "stable": [entry(e) for e in diff["matched"]],
     }
+
+
+def _download_xes(url: str) -> str:
+    """Stream an http(s) XES log to a local temp file, capped at the upload size limit.
+
+    The stream is read in chunks and aborted the moment it crosses
+    :data:`upload_guard.MAX_UPLOAD_BYTES`, so a malicious/oversized URL can't fill the
+    disk before the byte-size guard would have rejected it. The caller must have already
+    confirmed the scheme is http(s).
+    """
+    cap = upload_guard.MAX_UPLOAD_BYTES
+    fd, path = tempfile.mkstemp(suffix=".xes")
+    size = 0
+    try:
+        with os.fdopen(fd, "wb") as out, urlopen(url) as resp:  # noqa: S310 - scheme checked by caller
+            while chunk := resp.read(_DOWNLOAD_CHUNK):
+                size += len(chunk)
+                if size > cap:
+                    raise upload_guard.UploadRejected(
+                        f"the log at {url} exceeds the {cap / 1e6:.1f} MB upload cap."
+                    )
+                out.write(chunk)
+    except BaseException:
+        Path(path).unlink(missing_ok=True)  # never leave a partial/oversize download behind
+        raise
+    return path
+
+
+def resolve_source(source: str) -> str:
+    """Resolve an agent-supplied source string to a local XES path.
+
+    The MCP/REST tool (#116) can't drive the GUI's browser upload, so it names a log by a
+    string instead. Two forms are accepted:
+
+    * an **http(s) URL** to an XES log — downloaded to a size-capped temp file;
+    * the keyword **"example"** — the committed sepsis sample (a zero-setup input).
+
+    Bundled dataset names (``sepsis``, ``bpi2017`` …) are *not* live inputs: their full
+    logs aren't hosted on the live surface and their accuracy is a GUI-only concern
+    (ADR-0003), so they're rejected with a pointer to the Bundled tab. No other scheme is
+    fetched (no local-file / ``file://`` / ``ftp://`` reads — path/SSRF safety).
+
+    Args:
+        source: an ``http(s)`` URL to an XES log, or the keyword ``"example"``.
+
+    Returns:
+        A local filesystem path to an XES log, ready for :func:`forecast_live`.
+
+    Raises:
+        UploadRejected: the source is neither a supported keyword nor an http(s) URL, or
+            the downloaded log exceeds the upload size cap.
+    """
+    key = source.strip()
+    if key.lower() in _EXAMPLE_ALIASES:
+        return str(EXAMPLE_LOG)
+    if urlparse(key).scheme.lower() in ("http", "https"):
+        return _download_xes(key)
+    raise upload_guard.UploadRejected(
+        f"cannot resolve source {source!r}: provide an http(s) URL to an XES log, or the "
+        "keyword 'example' for the bundled sample. Bundled datasets (with their accuracy "
+        "metrics) are explorable in the GUI's Bundled tab, not via this tool."
+    )
 
 
 def forecast_live(

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -9,8 +9,9 @@
 #     only the lean, vendored demo modules (dfg_build / log_to_series / forecast_live).
 #
 # The gradio pin must match the README frontmatter `sdk_version`. graphviz also needs the
-# system `dot` binary — see packages.txt.
-gradio==6.16.0
+# system `dot` binary — see packages.txt. The `[mcp]` extra pulls in the `mcp` package that
+# `launch(mcp_server=True)` requires (#116) — plain `gradio` does not install it.
+gradio[mcp]==6.16.0
 spaces>=0.30
 graphviz>=0.20
 numpy>=1.24

--- a/demo/tests/test_demo.py
+++ b/demo/tests/test_demo.py
@@ -992,3 +992,108 @@ def test_tabs_carry_onboarding_accordions():
     explainers = [a for a in accordions if a.label == "What am I looking at?"]
     assert len(explainers) >= 2, "expected an onboarding accordion on each tab"
     assert all(not a.open for a in explainers), "the explainer should start collapsed"
+
+
+# ---------------------------------------------------------------------------
+# app.py — the agent surface (REST + MCP, slice 4, #116). Launching with
+# mcp_server=True turns each *public* API endpoint into an MCP tool whose schema
+# derives from its type hints + docstring. Only one endpoint is public — the live
+# forecast (forecast_from_source); every GUI/bundled listener is private, so the
+# bundled accuracy path never leaks to an agent (ADR-0003).
+# ---------------------------------------------------------------------------
+
+# A full live bundle (all seven keys forecast_live returns) for stubbing _run_live, so the
+# slim agent payload can be selected from it.
+_FULL_LIVE_BUNDLE = dict(
+    _LIVE_STUB_BUNDLE,
+    forecast_dfg={"nodes": [], "arcs": []},
+    comparison_dfg={"nodes": [], "arcs": []},
+)
+
+
+def _named_endpoints(app) -> set[str]:
+    """The public API endpoint names of the built app (the set MCP turns into tools)."""
+    return set(app.build().get_api_info()["named_endpoints"])
+
+
+def test_only_the_live_tool_is_a_public_api_endpoint():
+    """Exactly one public endpoint — the live forecast — is exposed, so flipping
+    mcp_server=True yields a single agent tool. Every GUI/bundled listener is private."""
+    pytest.importorskip("gradio")
+    import app
+
+    assert _named_endpoints(app) == {"/forecast_from_source"}
+
+
+def test_no_public_endpoint_exposes_the_bundled_path():
+    """The bundled handlers (load / load_diff / refresh) are never public endpoints, so an
+    agent can't reach precomputed accuracy through the API (AC#3)."""
+    pytest.importorskip("gradio")
+    import app
+
+    names = _named_endpoints(app)
+    for bundled in ("/load", "/load_diff", "/refresh", "/forecast_bundled"):
+        assert bundled not in names
+
+
+def test_forecast_from_source_returns_slim_drift_bundle(monkeypatch):
+    """The agent tool returns a *slim* bundle — DFG JSONs + drift only, no SVG strings and
+    never an accuracy metric — selected from the full live bundle."""
+    pytest.importorskip("gradio")
+    import app
+
+    monkeypatch.setattr(app, "_run_live", lambda path, model: dict(_FULL_LIVE_BUNDLE))
+    out = app.forecast_from_source("example", "chronos2")
+
+    assert set(out) == {"forecast_dfg", "comparison_dfg", "drift"}
+    assert not any(k.endswith("_svg") for k in out)
+    assert "metrics" not in out
+    blob = repr(out).lower()
+    assert "mae" not in blob and "rmse" not in blob and "actual" not in blob
+
+
+def test_forecast_from_source_resolves_example_to_the_committed_log(monkeypatch):
+    """'example' is resolved to the committed sample and handed to the GPU seam unchanged."""
+    pytest.importorskip("gradio")
+    import app
+
+    seen: dict[str, str] = {}
+
+    def _capture(path, model):
+        seen["path"], seen["model"] = path, model
+        return dict(_FULL_LIVE_BUNDLE)
+
+    monkeypatch.setattr(app, "_run_live", _capture)
+    app.forecast_from_source("example", "chronos2")
+
+    assert seen["path"] == str(app.EXAMPLE_LOG)
+    assert seen["model"] == "chronos2"
+
+
+def test_forecast_from_source_rejects_bad_source_before_gpu(monkeypatch):
+    """An unresolvable source (a bundled name) is rejected by resolve_source before the GPU
+    seam runs — the model is never reached for input the tool can't accept."""
+    pytest.importorskip("gradio")
+    import app
+    from upload_guard import UploadRejected
+
+    def _boom(path, model):
+        raise AssertionError("_run_live reached for an unresolved source")
+
+    monkeypatch.setattr(app, "_run_live", _boom)
+    with pytest.raises(UploadRejected):
+        app.forecast_from_source("sepsis")  # a bundled dataset name → GUI-only, rejected here
+
+
+def test_forecast_from_source_signature_is_the_mcp_schema():
+    """The tool's signature is the auto-derived MCP schema: every arg + the return typed,
+    and a docstring present (no hand-written schema anywhere)."""
+    import inspect
+
+    pytest.importorskip("gradio")
+    import app
+
+    sig = inspect.signature(app.forecast_from_source)
+    assert all(p.annotation is not inspect.Parameter.empty for p in sig.parameters.values())
+    assert sig.return_annotation is not inspect.Signature.empty
+    assert (app.forecast_from_source.__doc__ or "").strip()

--- a/demo/tests/test_deploy.py
+++ b/demo/tests/test_deploy.py
@@ -84,16 +84,22 @@ def test_readme_has_valid_hf_space_frontmatter():
     assert fm.get("suggested_hardware") == "zero-a10g", (
         "README must request ZeroGPU hardware (suggested_hardware: zero-a10g) for the live tab"
     )
-    # The pinned Space SDK version must agree with the serve-time requirements pin.
+    # The pinned Space SDK version must agree with the serve-time requirements pin. The gradio
+    # line may carry an extras bracket (``gradio[mcp]==`` for the MCP server, #116), so the
+    # match tolerates it while still reading the version after ``==``.
     req = (DEMO / "requirements.txt").read_text()
-    pin = next(
+    gradio_line = next(
         (
-            line.split("==", 1)[1].strip()
+            line.strip()
             for line in req.splitlines()
-            if line.strip().lower().startswith("gradio==")
+            if re.match(r"gradio(\[[^\]]*\])?==", line.strip())
         ),
         None,
     )
+    assert gradio_line is not None, "requirements.txt must pin gradio with `==`"
+    # mcp_server=True needs the `mcp` package, which only the `[mcp]` extra installs (#116).
+    assert "[mcp]" in gradio_line, "the gradio pin must carry the [mcp] extra for the MCP server"
+    pin = gradio_line.split("==", 1)[1].strip()
     assert fm["sdk_version"] == pin, (
         f"README sdk_version ({fm['sdk_version']}) must match requirements.txt gradio pin ({pin})"
     )

--- a/demo/tests/test_forecast_live.py
+++ b/demo/tests/test_forecast_live.py
@@ -8,11 +8,15 @@ are gradio-free and tested through their public interfaces:
 upload_guard.py
   - check_upload — size caps + model gating + default Chronos-2, clear rejections
 forecast_live.py
-  - drift_report  — DF relations partitioned as drift vs the recent past
-  - forecast_live — assembles the live bundle (drift, never accuracy) from a log
+  - drift_report   — DF relations partitioned as drift vs the recent past
+  - forecast_live  — assembles the live bundle (drift, never accuracy) from a log
+  - resolve_source — maps an agent-supplied URL / "example" keyword to a local XES path
 """
 
 from __future__ import annotations
+
+import io
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -335,3 +339,78 @@ def test_forecast_live_imports_no_gradio():
         [sys.executable, "-c", code], capture_output=True, text=True
     )
     assert result.returncode == 0, result.stderr
+
+
+# --- resolve_source (the agent-tool input resolver, #116) -------------------
+#
+# The MCP/REST tool can't drive a browser file picker, so it takes a *source string*:
+# an http(s) URL to an XES log, or the keyword "example". resolve_source maps that to a
+# local XES path forecast_live can read. It stays gradio/spaces-free (stdlib only).
+
+
+class _FakeResp:
+    """A stand-in for a urlopen() response: a readable, context-manager byte stream."""
+
+    def __init__(self, data: bytes):
+        self._buf = io.BytesIO(data)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._buf.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_resolve_source_example_keyword_returns_committed_log():
+    """The "example" (and "sepsis_sample") keyword resolves to the committed sample log,
+    so an agent has a zero-setup input — no URL needed to see the tool work."""
+    from forecast_live import EXAMPLE_LOG, resolve_source
+
+    assert resolve_source("example") == str(EXAMPLE_LOG)
+    assert resolve_source("sepsis_sample") == str(EXAMPLE_LOG)
+    assert Path(resolve_source("example")).exists()
+
+
+def test_resolve_source_rejects_bundled_name_pointing_to_gui():
+    """A bundled dataset name is *not* a live input: its full log isn't on the live surface
+    (accuracy lives in the GUI), so it's rejected with a message pointing there."""
+    from forecast_live import resolve_source
+
+    with pytest.raises(UploadRejected, match="http"):
+        resolve_source("sepsis")
+
+
+@pytest.mark.parametrize("bad", ["file:///etc/passwd", "ftp://host/log.xes", "/local/path.xes"])
+def test_resolve_source_rejects_non_http_scheme(bad):
+    """Only http(s) is fetched — no local-file or other-scheme reads (path/SSRF safety)."""
+    from forecast_live import resolve_source
+
+    with pytest.raises(UploadRejected):
+        resolve_source(bad)
+
+
+def test_resolve_source_downloads_http_url(monkeypatch):
+    """An http(s) URL is streamed to a local .xes temp file resolve_source returns."""
+    import forecast_live
+
+    payload = b"<log><trace/></log>"
+    monkeypatch.setattr(forecast_live, "urlopen", lambda url, *a, **k: _FakeResp(payload))
+
+    path = forecast_live.resolve_source("https://example.com/log.xes")
+
+    assert path.endswith(".xes")
+    assert Path(path).read_bytes() == payload
+
+
+def test_resolve_source_rejects_oversize_download(monkeypatch):
+    """A download past the upload byte cap is rejected (and not left on disk)."""
+    import forecast_live
+
+    monkeypatch.setattr(forecast_live.upload_guard, "MAX_UPLOAD_BYTES", 4)
+    monkeypatch.setattr(forecast_live, "urlopen", lambda url, *a, **k: _FakeResp(b"toolong"))
+
+    with pytest.raises(UploadRejected, match="cap"):
+        forecast_live.resolve_source("https://example.com/big.xes")


### PR DESCRIPTION
Closes #116 (Slice 4). Flips the one Gradio app to also serve a **REST API + MCP server** (`mcp_server=True`), exposing the **live forecast** as a single agent tool — per ADR-0003 (*one app, three surfaces: GUI + REST + MCP*).

## What changed
- **`forecast_live.resolve_source(source)`** — the agent tool can't drive the GUI file picker, so it takes a *source string*: an `http(s)` URL (streamed to a size-capped temp file) or the keyword `"example"` (the committed sepsis sample). Bundled dataset names, `file://`, `ftp://` are rejected. Stdlib-only — stays gradio/spaces-free.
- **`app.forecast_from_source(source, model)`** — resolve → the existing `@spaces.GPU` `_run_live` seam → a **slim** `{forecast_dfg, comparison_dfg, drift}` bundle (SVGs dropped; **never** accuracy). Registered via `gr.api` as the **one public endpoint**; every GUI listener is `api_visibility="private"`, so only this tool becomes an MCP/REST tool. Its type hints + docstring are the **auto-derived schema** (no manual wiring). `launch(mcp_server=True, show_error=True)` so a calling agent sees the clear `UploadRejected` reason.
- **`requirements.txt`** — `gradio[mcp]==6.16.0` (the `mcp` package `mcp_server=True` needs; plain `gradio` doesn't pull it in). README `sdk_version` pin unchanged.
- **Tests (+13)** — `resolve_source` (URL/example/reject paths) and the agent surface (exactly one public endpoint; slim never-accuracy payload; schema from the signature). Deploy-test gradio-pin parser tolerates the `[mcp]` extras bracket. **72 gradio-free / 95 with `gradio[mcp]`, ruff clean.**
- **`README.md`** — new "Agent API (REST + MCP)" section.

## Acceptance criteria (#116) — verified on a live local launch
- ✅ App launches with `mcp_server=True`; **REST** (`gradio_client`) **and** **MCP** (SSE) both reachable.
- ✅ Tool exposes the live forecast and accepts a **URL or `example` keyword** (not a file picker). Real CPU Chronos-2 forecast returned a drift bundle on both inputs.
- ✅ Tool **never** returns precomputed bundled metrics — only `forecast_from_source` is public; payload has no ER/MAE/RMSE.
- ✅ Schema derives from type hints + docstring (one MCP tool, params `source`/`model`).

## Notes
- **Why a bundled dataset name isn't accepted:** the full processed XES logs are 135M–585M, untracked, and live outside `demo/`, so they can't ship to the Space. Only the committed 269 KB example is resolvable there → `example` keyword + URL are the inputs.
- **MCP serialization quirk:** over REST the return is a proper JSON dict; over MCP, Gradio 6.16 serializes the dict as a Python-repr string in the text block (agents read it fine) — a framework presentation detail, not a bug here.
- **Real GPU run is HITL on the Space** after merge (auto-deploys on `demo/` changes); local verification was on CPU.