### PR TITLE
feat(core): pmf_tsfm.api seam + XES→series bridge (#132)

### DIFF
--- a/src/pmf_tsfm/api.py
+++ b/src/pmf_tsfm/api.py
@@ -1,0 +1,245 @@
+"""Agent-clean, Gradio-free entry points over the core forecasting pipeline (issue #132).
+
+This is the **shared seam** the dev-ready MCP (#133) and Docker (#134) artifacts build on:
+plain Python functions that let a user run the *real* ``src/pmf_tsfm`` pipeline on their
+**own** process log — a raw ``.xes`` (auto-converted to the daily DF-relation series) or a
+prepared DF-relation ``.parquet``.
+
+Scope (locked, ADR-0004): **zero-shot holdout backtest** only — no training. The natural
+60/20/20 split holds out the tail of the series; the existing expanding-window zero-shot
+pipeline forecasts the held-out region from prior history and scores it (genuine accuracy:
+MAE/RMSE, plus Entropic Relevance when an XES log is available).
+
+These functions **compose the existing Hydra configs** and **call the existing cores**
+(``inference.run_inference``, ``evaluate.evaluate_single``, ``er.evaluate_er.run_er_evaluation``)
+rather than reimplementing anything — so the numbers match the paper/CLI.
+
+Import-light by design: heavy deps (torch via the core modules, the model libraries) are
+imported **inside** the functions, so ``import pmf_tsfm.api`` pulls no model library, no
+Gradio, and triggers no CUDA init or weight download.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+# Repo layout: this file is src/pmf_tsfm/api.py → parents[2] is the repo root.
+_CONFIGS_DIR = Path(__file__).resolve().parents[2] / "configs"
+
+_XES_SUFFIXES = (".xes.gz", ".xes")
+
+
+def list_models() -> list[str]:
+    """Available model config groups, e.g. ``"chronos/chronos2"``, ``"moirai/2_0_small"``.
+
+    These are exactly the values accepted by the ``model=`` argument of the forecast
+    functions (the Hydra config-group path under ``configs/model/``). Pure and cheap —
+    no model import.
+    """
+    model_dir = _CONFIGS_DIR / "model"
+    return sorted(str(p.relative_to(model_dir).with_suffix("")) for p in model_dir.rglob("*.yaml"))
+
+
+def _is_xes(path: Path) -> bool:
+    return path.name.lower().endswith(_XES_SUFFIXES)
+
+
+def _resolve_input(
+    input_path: Path,
+    workdir: Path,
+    log_dir: str,
+    train_end: int | None,
+    val_end: int | None,
+) -> tuple[dict, bool]:
+    """Build the in-code data config for the run; returns ``(data_cfg, has_xes)``.
+
+    ``.xes``/``.xes.gz`` → convert to the daily DF-relation parquet (and stage the log
+    for ER). ``.parquet`` → use as-is. Caller-supplied ``train_end``/``val_end`` override
+    the derived 60/20/20 split.
+    """
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input not found: {input_path}")
+
+    if _is_xes(input_path):
+        from pmf_tsfm.data.log_to_series import prepare_series_from_log
+
+        data = prepare_series_from_log(input_path, workdir / "series.parquet", log_dir=log_dir)
+        has_xes = True
+    elif input_path.suffix.lower() == ".parquet":
+        import pandas as pd
+
+        n = len(pd.read_parquet(input_path, columns=[]))
+        data = {
+            "name": input_path.stem,
+            "path": str(input_path.resolve()),
+            "train_end": int(n * 0.6),
+            "val_end": int(n * 0.8),
+        }
+        has_xes = False
+    else:
+        raise ValueError(
+            f"Unsupported input '{input_path.name}'. Expected .xes/.xes.gz or .parquet."
+        )
+
+    if train_end is not None:
+        data["train_end"] = int(train_end)
+    if val_end is not None:
+        data["val_end"] = int(val_end)
+    return data, has_xes
+
+
+def _run(
+    input_path: str | Path,
+    model: str,
+    horizon: int,
+    device: str,
+    train_end: int | None,
+    val_end: int | None,
+    workdir: str | Path | None,
+):
+    """Compose the config, resolve the input, and run inference. Returns ``(cfg, result)``."""
+    from hydra import compose, initialize_config_dir
+    from omegaconf import OmegaConf
+
+    input_path = Path(input_path)
+    workdir = Path(workdir) if workdir is not None else Path(tempfile.mkdtemp(prefix="pmf_api_"))
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # Compose the same config tree the CLI uses. Overriding paths.root_dir to the scratch
+    # workdir isolates all outputs/log_dir/processed_dir per run AND replaces the
+    # ${hydra:runtime.cwd} resolver (which is unavailable under bare compose) with a literal.
+    with initialize_config_dir(version_base="1.3", config_dir=str(_CONFIGS_DIR)):
+        cfg = compose(
+            config_name="inference",
+            overrides=[
+                f"model={model}",
+                f"device={device}",
+                f"prediction_length={horizon}",
+                "logger=disabled",
+                f"paths.root_dir={workdir}",
+            ],
+        )
+
+    data, has_xes = _resolve_input(input_path, workdir, cfg.paths.log_dir, train_end, val_end)
+    OmegaConf.set_struct(cfg, False)
+    cfg.data = OmegaConf.create(data)
+
+    from pmf_tsfm.inference import run_inference
+
+    result = run_inference(cfg)
+    return cfg, result, has_xes
+
+
+def _artifact_paths(cfg, output_path: Path) -> tuple[Path, Path, list[str] | None]:
+    """Prediction/quantile npy paths + feature names (from the metadata inference wrote)."""
+    prefix = f"{cfg.data.name}_{cfg.model.name}"
+    predictions_path = output_path / f"{prefix}_predictions.npy"
+    quantiles_path = output_path / f"{prefix}_quantiles.npy"
+
+    feature_names: list[str] | None = None
+    meta_path = output_path / f"{prefix}_metadata.json"
+    if meta_path.exists():
+        with open(meta_path) as f:
+            feature_names = json.load(f).get("feature_names")
+    return predictions_path, quantiles_path, feature_names
+
+
+def forecast_only(
+    input_path: str | Path,
+    model: str = "chronos/chronos2",
+    horizon: int = 7,
+    device: str = "cpu",
+    train_end: int | None = None,
+    val_end: int | None = None,
+    workdir: str | Path | None = None,
+) -> dict:
+    """Zero-shot forecast over the held-out tail; return predictions, skip scoring.
+
+    See :func:`forecast_backtest` for the argument and return shape; ``metrics`` is
+    ``None`` here.
+    """
+    cfg, result, _ = _run(input_path, model, horizon, device, train_end, val_end, workdir)
+    output_path = Path(result["output_path"])
+    predictions_path, quantiles_path, feature_names = _artifact_paths(cfg, output_path)
+    return {
+        "predictions_path": str(predictions_path),
+        "quantiles_path": str(quantiles_path),
+        "metrics": None,
+        "feature_names": feature_names,
+        "n_windows": int(result["predictions"].shape[0]),
+        "model": cfg.model.name,
+        "horizon": int(cfg.prediction_length),
+    }
+
+
+def forecast_backtest(
+    input_path: str | Path,
+    model: str = "chronos/chronos2",
+    horizon: int = 7,
+    device: str = "cpu",
+    train_end: int | None = None,
+    val_end: int | None = None,
+    workdir: str | Path | None = None,
+    compute_er: bool = True,
+) -> dict:
+    """Zero-shot holdout backtest on a user's process log; forecast + score.
+
+    Args:
+        input_path: Raw ``.xes``/``.xes.gz`` log (auto-converted) or a prepared
+                    DF-relation ``.parquet``.
+        model:      Model config group, e.g. ``"chronos/chronos2"`` (see :func:`list_models`).
+        horizon:    Forecast/holdout length in days.
+        device:     ``"cpu"``, ``"cuda"``, or ``"mps"`` (falls back to CPU if unavailable).
+        train_end/val_end: Override the derived 60/20/20 split indices.
+        workdir:    Scratch dir for the run (default: a fresh temp dir).
+        compute_er: Compute Entropic Relevance (only possible for ``.xes`` input).
+
+    Returns:
+        ``{predictions_path, quantiles_path, metrics, feature_names, n_windows, model,
+        horizon}`` where ``metrics = {mae, mae_std, rmse, rmse_std, er}``. ``er`` is
+        ``None`` for ``.parquet`` input (no log to build truth/training DFGs) or when
+        ``compute_er=False``.
+    """
+    cfg, result, has_xes = _run(input_path, model, horizon, device, train_end, val_end, workdir)
+    output_path = Path(result["output_path"])
+    predictions_path, quantiles_path, feature_names = _artifact_paths(cfg, output_path)
+
+    from pmf_tsfm.evaluate import evaluate_single
+
+    summary = evaluate_single(output_path, cfg.data.name, cfg.model.name, save=True)["summary"]
+    metrics = {
+        "mae": summary["MAE_mean"],
+        "mae_std": summary["MAE_std"],
+        "rmse": summary["RMSE_mean"],
+        "rmse_std": summary["RMSE_std"],
+        "er": None,
+    }
+
+    if compute_er and has_xes:
+        from omegaconf import OmegaConf
+
+        from pmf_tsfm.er.evaluate_er import run_er_evaluation
+
+        # run_er_evaluation joins cfg.task into a path expecting a string, but the
+        # inference config makes cfg.task a node. Fully resolve, then coerce task to its
+        # name and pin a concrete ER output dir so no lazy interpolation remains.
+        task_name = cfg.task.name
+        er_cfg = OmegaConf.create(OmegaConf.to_container(cfg, resolve=True))
+        er_cfg.task = task_name
+        er_cfg.output_dir = str(
+            Path(cfg.paths.output_dir) / "er" / task_name / cfg.data.name / cfg.model.name
+        )
+        er = run_er_evaluation(er_cfg)
+        metrics["er"] = er["summary"]["pred_er_mean"]
+
+    return {
+        "predictions_path": str(predictions_path),
+        "quantiles_path": str(quantiles_path),
+        "metrics": metrics,
+        "feature_names": feature_names,
+        "n_windows": int(result["predictions"].shape[0]),
+        "model": cfg.model.name,
+        "horizon": int(cfg.prediction_length),
+    }

--- a/src/pmf_tsfm/data/log_to_series.py
+++ b/src/pmf_tsfm/data/log_to_series.py
@@ -1,0 +1,179 @@
+"""Convert an XES event log into the daily DF-relation frequency series.
+
+A faithful in-repo port of the external `pmf-benchmark`_ preprocessing
+(``preprocessing/{event_log_processor,df_generator,time_series_creator}.py``) that
+produced this repo's ``data/time_series/*.parquet``. h5↔parquet verification (#115)
+confirmed that pipeline is the producer of the repo's series, so this port
+reproduces the same representation the paper's TSFMs were applied to.
+
+This is the **core** copy (issue #132): the shared seam under ``pmf_tsfm.api`` lifts
+the same converter the demo's live path uses (``demo/log_to_series.py``) so users can
+bring a raw ``.xes`` log. The demo keeps its own standalone copy — it is deliberately
+``pmf_tsfm``-free for its lean serve env, so it cannot import this one; a drift guard
+(``tests/test_log_to_series.py``) keeps the two converter bodies byte-identical.
+
+The pipeline, per upstream:
+
+1. read the XES log (pm4py),
+2. ``filter_variants_by_coverage_percentage`` — drop ultra-rare variants (mild; a
+   no-op on normal logs),
+3. ``insert_artificial_start_end`` — add the ▶ / ■ events (the source of the
+   ``▶ -> X`` / ``X -> ■`` columns),
+4. extract every consecutive-event DF pair ``"a -> b"`` recording the **source
+   event's** timestamp,
+5. lay the counts on a daily ``date_range`` over the log's span, bucketing each pair
+   by its **source-event day**.
+
+**Deliberate deviation from upstream:** upstream also trims 10% of the timespan off
+*each* end before step 4. This converter **omits the end-trim** — the backtest path
+forecasts the genuine future *from the log end* (ADR-0004), so trimming the recent
+end would discard exactly the window the forecast is anchored on. Fidelity to the
+training preprocessing is not a correctness gate here; what matters is that the
+forecast and last-known windows share one feature space, which they do — both are
+columns of this one frame.
+
+Heavy deps are lazy: ``pm4py`` is imported inside the functions, so importing this
+module (and ``pmf_tsfm.api``) stays cheap.
+
+.. _pmf-benchmark: https://github.com/YongboYu/pmf-benchmark
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+CASE_KEY = "case:concept:name"
+ACT_KEY = "concept:name"
+TS_KEY = "time:timestamp"
+
+# Match pmf-benchmark's preprocessing_config.yaml (event_log.filter_percentage).
+DEFAULT_FILTER_COVERAGE = 0.0001
+
+
+def log_to_df_series(
+    log: str | Path, *, filter_coverage: float = DEFAULT_FILTER_COVERAGE
+) -> pd.DataFrame:
+    """Read an XES log and return its daily DF-relation frequency series.
+
+    Args:
+        log:             Path to the uploaded XES event log.
+        filter_coverage: Variant-coverage threshold for the rare-variant filter
+                         (upstream default ``0.0001``); pass ``0`` to skip filtering.
+
+    Returns:
+        A ``(days × DF-relations)`` frame: a daily ``DatetimeIndex`` over the log's
+        full span and one ``"a -> b"`` column per directly-follows relation (with the
+        artificial ▶ / ■ markers), each cell the count of that relation whose source
+        event fell on that day.
+    """
+    import pm4py
+
+    df = pm4py.read_xes(str(log))
+    return event_df_to_series(df, filter_coverage=filter_coverage)
+
+
+def event_df_to_series(
+    df: pd.DataFrame, *, filter_coverage: float = DEFAULT_FILTER_COVERAGE
+) -> pd.DataFrame:
+    """Daily DF-relation series from an already-loaded event-log DataFrame.
+
+    Split out from :func:`log_to_df_series` so the assembly is testable without an
+    XES round-trip. Expects the standard XES columns (``case:concept:name``,
+    ``concept:name``, ``time:timestamp``).
+    """
+    import pm4py
+
+    df = pm4py.format_dataframe(df, case_id=CASE_KEY, activity_key=ACT_KEY, timestamp_key=TS_KEY)
+    if filter_coverage:
+        df = pm4py.filter_variants_by_coverage_percentage(df, filter_coverage)
+    # Artificial ▶ / ■ events (timestamps ±1ms around each case's first/last event), so
+    # the ``▶ -> first`` / ``last -> ■`` relations exist and bucket on the right day.
+    df = pm4py.insert_artificial_start_end(df)
+
+    work = df[[CASE_KEY, ACT_KEY, TS_KEY]].copy()
+    work[TS_KEY] = pd.to_datetime(work[TS_KEY], utc=True)
+    work = work.sort_values([CASE_KEY, TS_KEY])
+
+    # Each event's directly-following successor within its case; the last event per
+    # case has none (NaN) and contributes no outgoing relation.
+    work["_next"] = work.groupby(CASE_KEY, sort=False)[ACT_KEY].shift(-1)
+    pairs = work.dropna(subset=["_next"]).copy()
+    pairs["_relation"] = pairs[ACT_KEY].astype(str) + " -> " + pairs["_next"].astype(str)
+    # Bucket by the SOURCE event's calendar day (upstream uses ``start_time``).
+    pairs["_day"] = pairs[TS_KEY].dt.tz_convert("UTC").dt.tz_localize(None).dt.normalize()
+
+    counts = pairs.groupby(["_day", "_relation"]).size().unstack(fill_value=0)
+
+    # Lay the counts on a contiguous daily index over the full (untrimmed) log span —
+    # the artificial events keep ▶/■ on the adjacent real-event days, so this spans
+    # exactly the log's active days.
+    span = work[TS_KEY].dt.tz_convert("UTC").dt.tz_localize(None).dt.normalize()
+    days = pd.date_range(span.min(), span.max(), freq="D")
+    series = counts.reindex(days, fill_value=0).astype(int)
+    series.index.name = "date"
+    series.columns.name = None
+    return series
+
+
+def _log_name(xes_path: str | Path) -> str:
+    """Dataset name from an XES path stem, stripping ``.xes`` / ``.xes.gz``."""
+    name = Path(xes_path).name
+    for suffix in (".xes.gz", ".xes"):
+        if name.lower().endswith(suffix):
+            return name[: -len(suffix)]
+    return Path(xes_path).stem
+
+
+def prepare_series_from_log(
+    xes_path: str | Path,
+    out_parquet: str | Path,
+    *,
+    split_ratio: tuple[float, float, float] = (0.6, 0.2, 0.2),
+    log_dir: str | Path | None = None,
+) -> dict:
+    """Build the daily DF-relation parquet a backtest run needs from a raw XES log.
+
+    Writes the ``(days × DF-relations)`` frame to ``out_parquet`` **with its
+    ``DatetimeIndex`` retained** — the Entropic Relevance evaluator reads the test-window
+    dates straight off this index (``er/evaluate_er.py:_get_test_dates``), so the index
+    must stay datetime. When ``log_dir`` is given, the source ``.xes`` is copied to
+    ``{log_dir}/{name}.xes`` because ER reads the log at ``cfg.paths.log_dir/<name>.xes``.
+
+    Args:
+        xes_path:    Path to the raw XES event log.
+        out_parquet: Where to write the daily DF-relation parquet.
+        split_ratio: ``(train, val, test)`` fractions; absolute split indices are
+                     derived from the row count by flooring, matching the committed
+                     dataset configs (e.g. bpi2017 319 → 191/255, sepsis 459 → 275/367).
+        log_dir:     If given, copy the XES there as ``{name}.xes`` for ER.
+
+    Returns:
+        ``{"name", "path", "train_end", "val_end"}`` — the data config the API sets in
+        code for ``ZeroShotDataModule.from_config`` (it reads exactly these keys).
+    """
+    import shutil
+
+    name = _log_name(xes_path)
+    series = log_to_df_series(xes_path)
+
+    out_parquet = Path(out_parquet)
+    out_parquet.parent.mkdir(parents=True, exist_ok=True)
+    series.to_parquet(out_parquet)  # DatetimeIndex retained
+
+    n = len(series)
+    train_end = int(n * split_ratio[0])
+    val_end = int(n * (split_ratio[0] + split_ratio[1]))
+
+    if log_dir is not None:
+        log_dir = Path(log_dir)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(xes_path, log_dir / f"{name}.xes")
+
+    return {
+        "name": name,
+        "path": str(out_parquet),
+        "train_end": train_end,
+        "val_end": val_end,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,228 @@
+"""Tests for the agent-clean ``pmf_tsfm.api`` seam (issue #132).
+
+The API *composes* the existing Hydra configs and *calls* the existing cores
+(``run_inference`` / ``evaluate_single`` / ``run_er_evaluation``). These tests verify the
+**wiring** without downloading model weights — following the repo convention
+(``test_pipeline_integration.py``): monkeypatch ``get_model_adapter`` with a tiny mock so
+``run_inference`` exercises every code path on CPU in seconds. The genuine Chronos-2 run is
+a slow, file-gated tracer bullet at the bottom (skips in CI, which lacks the local log).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pmf_tsfm import api
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SEPSIS_XES = _REPO_ROOT / "data" / "processed_logs" / "sepsis.xes"
+
+CASE, ACT, TS = "case:concept:name", "concept:name", "time:timestamp"
+
+
+# ===========================================================================
+# Tiny mock adapter (no weights, no network) — matches the BaseAdapter calls
+# run_inference makes: get_model_adapter(...) → load_model() → predict(...).
+# ===========================================================================
+
+
+class _MockAdapter:
+    def __init__(self, prediction_length: int = 7, device: str = "cpu", **_):
+        self.prediction_length = prediction_length
+        self.device = device
+
+    def load_model(self) -> None:
+        pass
+
+    def predict(self, prepared_data, prediction_length=None, **_):
+        pred_len = prediction_length or self.prediction_length
+        n_seq = len(prepared_data["inputs"])
+        n_feat = len(prepared_data["feature_names"])
+        rng = np.random.default_rng(0)
+        preds = np.abs(rng.standard_normal((n_seq, pred_len, n_feat))).astype(np.float32)
+        quants = np.abs(rng.standard_normal((n_seq, pred_len, n_feat, 3))).astype(np.float32)
+        return preds, quants
+
+
+@pytest.fixture
+def use_mock_adapter(monkeypatch):
+    """Make run_inference use the mock adapter (it imports get_model_adapter at module top)."""
+    monkeypatch.setattr(
+        "pmf_tsfm.inference.get_model_adapter",
+        lambda **kw: _MockAdapter(**kw),
+    )
+
+
+@pytest.fixture
+def synthetic_parquet(tmp_path):
+    """60-day daily DF-relation series with a retained DatetimeIndex."""
+    n = 60
+    cols = ["▶ -> A", "A -> B", "B -> C", "C -> ■", "A -> C"]
+    rng = np.random.default_rng(1)
+    idx = pd.date_range("2022-01-01", periods=n, freq="D")
+    df = pd.DataFrame(rng.integers(0, 9, size=(n, len(cols))), index=idx, columns=cols)
+    df.index.name = "date"
+    path = tmp_path / "synthetic.parquet"
+    df.to_parquet(path)
+    return path
+
+
+def _write_tiny_xes(path: Path, *, days: int = 15) -> None:
+    """A dense daily A→B log spanning ``days`` calendar days → a ``days``-row series."""
+    import pm4py
+
+    rows = []
+    for d in range(days):
+        day = f"2022-05-{d + 1:02d}"
+        rows += [(f"c{d}", "A", f"{day} 09:00"), (f"c{d}", "B", f"{day} 10:00")]
+    df = pd.DataFrame(rows, columns=[CASE, ACT, TS])
+    df[TS] = pd.to_datetime(df[TS], utc=True)
+    pm4py.write_xes(df, str(path), case_id_key=CASE)
+
+
+# ===========================================================================
+# list_models + import-light
+# ===========================================================================
+
+
+def test_list_models_includes_known_groups():
+    models = api.list_models()
+    assert "chronos/chronos2" in models
+    assert any(m.startswith("moirai/") for m in models)
+    assert any(m.startswith("timesfm/") for m in models)
+    assert models == sorted(models)
+
+
+def test_importing_api_pulls_no_model_library_or_gradio():
+    """`import pmf_tsfm.api` must not import a model lib / Gradio / init CUDA."""
+    code = (
+        "import sys; import pmf_tsfm.api; "
+        "bad = [m for m in ('chronos', 'gradio', 'uni2ts', 'timesfm') if m in sys.modules]; "
+        "print('LEAKED:' + ','.join(bad) if bad else 'CLEAN')"
+    )
+    out = subprocess.run(  # noqa: S603 — fixed argv, no shell, hardcoded snippet
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    assert "CLEAN" in out.stdout, out.stdout + out.stderr
+
+
+# ===========================================================================
+# forecast_backtest / forecast_only on a prepared parquet (mock adapter)
+# ===========================================================================
+
+
+def test_forecast_backtest_parquet_returns_finite_metrics(
+    synthetic_parquet, use_mock_adapter, tmp_path
+):
+    res = api.forecast_backtest(
+        synthetic_parquet, model="chronos/chronos2", horizon=7, workdir=tmp_path / "wd"
+    )
+
+    # n_windows = total - val_end - horizon + 1 = 60 - 48 - 7 + 1 = 6.
+    assert res["n_windows"] == 6
+    assert res["model"] == "chronos_2" and res["horizon"] == 7
+
+    m = res["metrics"]
+    for key in ("mae", "mae_std", "rmse", "rmse_std"):
+        assert np.isfinite(m[key])
+    # Parquet-only input → no XES → ER cannot be computed.
+    assert m["er"] is None
+
+    assert Path(res["predictions_path"]).exists()
+    assert Path(res["quantiles_path"]).exists()
+    assert res["feature_names"] == ["▶ -> A", "A -> B", "B -> C", "C -> ■", "A -> C"]
+
+
+def test_parquet_only_er_branch_is_skipped(
+    synthetic_parquet, use_mock_adapter, monkeypatch, tmp_path
+):
+    """compute_er=True on parquet input must NOT call the ER core (no log available)."""
+    called = {"er": False}
+
+    def _boom(_cfg):
+        called["er"] = True
+        raise AssertionError("ER should not run for parquet-only input")
+
+    monkeypatch.setattr("pmf_tsfm.er.evaluate_er.run_er_evaluation", _boom)
+    res = api.forecast_backtest(
+        synthetic_parquet, model="chronos/chronos2", workdir=tmp_path / "wd", compute_er=True
+    )
+    assert res["metrics"]["er"] is None
+    assert called["er"] is False
+
+
+def test_forecast_only_skips_metrics(synthetic_parquet, use_mock_adapter, tmp_path):
+    res = api.forecast_only(synthetic_parquet, model="chronos/chronos2", workdir=tmp_path / "wd")
+    assert res["metrics"] is None
+    assert res["n_windows"] == 6
+    assert Path(res["predictions_path"]).exists()
+
+
+def test_train_end_val_end_override_split(synthetic_parquet, use_mock_adapter, tmp_path):
+    res = api.forecast_only(
+        synthetic_parquet, horizon=5, train_end=30, val_end=40, workdir=tmp_path / "wd"
+    )
+    # n_windows = 60 - 40 - 5 + 1 = 16.
+    assert res["n_windows"] == 16
+
+
+# ===========================================================================
+# ER branch wiring for XES input — guards the cfg.task node→string gotcha
+# ===========================================================================
+
+
+def test_xes_input_runs_er_with_string_task(use_mock_adapter, monkeypatch, tmp_path):
+    """`.xes` input triggers ER; the ER cfg must carry `task` as the *string* "zero_shot".
+
+    run_er_evaluation joins cfg.task into a path expecting a string, but the inference
+    config makes cfg.task a node — this regression-guards the coercion the API does.
+    """
+    xes = tmp_path / "mylog.xes"
+    _write_tiny_xes(xes, days=15)
+
+    captured = {}
+
+    def _spy(er_cfg):
+        captured["task"] = er_cfg.task
+        captured["output_dir"] = er_cfg.output_dir
+        captured["data_path"] = er_cfg.data.path
+        return {"summary": {"pred_er_mean": 1.23}}
+
+    monkeypatch.setattr("pmf_tsfm.er.evaluate_er.run_er_evaluation", _spy)
+
+    res = api.forecast_backtest(
+        xes, model="chronos/chronos2", horizon=2, workdir=tmp_path / "wd", compute_er=True
+    )
+
+    assert res["metrics"]["er"] == 1.23
+    assert captured["task"] == "zero_shot"
+    assert isinstance(captured["task"], str)
+    # ER output dir is concrete (resolved) and points under the scratch workdir.
+    assert "/er/zero_shot/mylog/chronos_2" in captured["output_dir"]
+    assert captured["data_path"].endswith("series.parquet")
+
+
+# ===========================================================================
+# Genuine Chronos-2 tracer bullet (slow; needs the local sepsis log → skips in CI)
+# ===========================================================================
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not _SEPSIS_XES.exists(),
+    reason="needs local data/processed_logs/sepsis.xes (not in CI); downloads Chronos-2",
+)
+def test_chronos2_end_to_end_on_sepsis(tmp_path):
+    res = api.forecast_backtest(
+        _SEPSIS_XES, model="chronos/chronos2", horizon=7, device="cpu", workdir=tmp_path / "wd"
+    )
+    m = res["metrics"]
+    assert np.isfinite(m["mae"]) and np.isfinite(m["rmse"])
+    assert isinstance(m["er"], float)  # XES input → ER computed
+    assert res["n_windows"] >= 1

--- a/tests/test_log_to_series.py
+++ b/tests/test_log_to_series.py
@@ -1,0 +1,234 @@
+"""Tests for the core XES→daily-DF-series converter (issue #132).
+
+``pmf_tsfm.data.log_to_series`` is the in-repo, faithful port of the external
+``pmf-benchmark`` preprocessing that produced this repo's ``data/time_series/*.parquet``.
+It turns a raw XES log into the daily ``(days × DF-relations)`` frequency frame the TSFM
+forecasts, and ``prepare_series_from_log`` packages it (parquet + split indices + staged
+log) for ``pmf_tsfm.api``.
+
+This file mirrors the demo's converter tests against the core copy, adds the
+``prepare_series_from_log`` packaging contract, a parity cross-check against the committed
+``bpi2017`` series, and a **drift guard** keeping the core and demo converters identical
+(the demo keeps its own ``pmf_tsfm``-free copy for its lean serve env — two copies are
+unavoidable, so we pin them together).
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pmf_tsfm.data.log_to_series import (
+    event_df_to_series,
+    log_to_df_series,
+    prepare_series_from_log,
+)
+
+CASE, ACT, TS = "case:concept:name", "concept:name", "time:timestamp"
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_BPI2017_XES = _REPO_ROOT / "data" / "processed_logs" / "bpi2017.xes"
+_BPI2017_PARQUET = _REPO_ROOT / "data" / "time_series" / "bpi2017.parquet"
+
+
+def _event_df(rows):
+    """Build a tidy event-log DataFrame from ``(case, activity, "YYYY-MM-DD HH:MM")`` rows."""
+    df = pd.DataFrame(rows, columns=[CASE, ACT, TS])
+    df[TS] = pd.to_datetime(df[TS], utc=True)
+    return df
+
+
+# A 2-case log: c1 spans 01-01..01-02, c2 is all on 01-03. Hand-traced expectation
+# (bucket every DF pair by its SOURCE event's day):
+#   01-01: ▶->A, A->B, B->C        01-02: C->■        01-03: ▶->A, A->B, B->■
+_FIXTURE = [
+    ("c1", "A", "2020-01-01 09:00"),
+    ("c1", "B", "2020-01-01 10:00"),
+    ("c1", "C", "2020-01-02 09:00"),
+    ("c2", "A", "2020-01-03 09:00"),
+    ("c2", "B", "2020-01-03 11:00"),
+]
+
+
+@pytest.fixture
+def series():
+    return event_df_to_series(_event_df(_FIXTURE))
+
+
+# ---------------------------------------------------------------------------
+# Converter semantics (mirrors demo/tests/test_log_to_series.py)
+# ---------------------------------------------------------------------------
+
+
+def test_index_is_contiguous_daily_over_the_full_span(series):
+    """The index is one row per calendar day across the whole (untrimmed) log span."""
+    assert list(series.index) == list(pd.date_range("2020-01-01", "2020-01-03", freq="D"))
+    assert (series.index.to_series().diff().dropna() == pd.Timedelta(days=1)).all()
+
+
+def test_index_is_a_named_datetime_index(series):
+    """ER reads test-window dates off this index, so it must be a DatetimeIndex named 'date'."""
+    assert isinstance(series.index, pd.DatetimeIndex)
+    assert series.index.name == "date"
+
+
+def test_columns_are_df_relations_with_artificial_markers(series):
+    """Columns are ``"a -> b"`` DF relations, including the artificial ▶ / ■ markers."""
+    cols = set(series.columns)
+    assert {"▶ -> A", "A -> B", "B -> C", "C -> ■", "B -> ■"} == cols
+    assert all(" -> " in c for c in cols)  # the exact separator dfg_to_json splits on
+
+
+def test_relations_bucket_on_the_source_event_day(series):
+    """Each DF pair is counted on the day of its *source* event (pmf-benchmark semantics)."""
+    assert series.at[pd.Timestamp("2020-01-01"), "A -> B"] == 1
+    assert series.at[pd.Timestamp("2020-01-03"), "A -> B"] == 1
+    assert series.at[pd.Timestamp("2020-01-02"), "A -> B"] == 0
+
+
+def test_cross_day_relation_counts_on_the_source_not_target_day(series):
+    """B(01-01)->C(01-02) is a cross-day pair; it counts on 01-01 (source), not 01-02."""
+    assert series.at[pd.Timestamp("2020-01-01"), "B -> C"] == 1
+    assert series.at[pd.Timestamp("2020-01-02"), "B -> C"] == 0
+
+
+def test_end_event_relation_counts_on_its_source_day(series):
+    """C->■ (c1's close) buckets on C's day (01-02); the path keeps that final day."""
+    assert series.at[pd.Timestamp("2020-01-02"), "C -> ■"] == 1
+
+
+def test_log_to_df_series_reads_xes(tmp_path):
+    """The public entry reads an XES file and yields the same frame as the in-memory path."""
+    import pm4py
+
+    df = _event_df(_FIXTURE)
+    xes = tmp_path / "tiny.xes"
+    pm4py.write_xes(df, str(xes), case_id_key=CASE)
+
+    from_file = log_to_df_series(xes)
+    in_memory = event_df_to_series(df)
+    a = from_file.reindex(sorted(from_file.columns), axis=1).sort_index()
+    b = in_memory.reindex(sorted(in_memory.columns), axis=1).sort_index()
+    pd.testing.assert_frame_equal(a, b, check_dtype=False)
+
+
+# ---------------------------------------------------------------------------
+# prepare_series_from_log packaging contract
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_series_from_log_writes_datetime_parquet_and_derives_splits(tmp_path):
+    """Writes a datetime-indexed parquet, derives 60/20/20 splits, and stages the XES."""
+    import pm4py
+
+    # 15 consecutive daily A→B cases → a 15-row daily series.
+    rows = []
+    for d in range(15):
+        day = f"2021-03-{d + 1:02d}"
+        rows += [(f"c{d}", "A", f"{day} 09:00"), (f"c{d}", "B", f"{day} 10:00")]
+    xes = tmp_path / "mylog.xes"
+    pm4py.write_xes(_event_df(rows), str(xes), case_id_key=CASE)
+
+    out_parquet = tmp_path / "out" / "series.parquet"
+    log_dir = tmp_path / "logs"
+    info = prepare_series_from_log(xes, out_parquet, log_dir=log_dir)
+
+    assert info["name"] == "mylog"
+    assert info["path"] == str(out_parquet)
+    # 15 rows → floor(15*0.6)=9, floor(15*0.8)=12.
+    assert (info["train_end"], info["val_end"]) == (9, 12)
+
+    # Parquet exists with a retained DatetimeIndex.
+    df = pd.read_parquet(out_parquet)
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert len(df) == 15
+
+    # XES staged for ER at {log_dir}/{name}.xes.
+    assert (log_dir / "mylog.xes").exists()
+
+
+def test_prepare_series_from_log_strips_xes_gz_suffix(tmp_path):
+    """``name`` strips ``.xes.gz`` (not just ``.xes``)."""
+    import pm4py
+
+    xes = tmp_path / "compressed.xes.gz"
+    pm4py.write_xes(_event_df(_FIXTURE), str(xes), case_id_key=CASE)
+    info = prepare_series_from_log(xes, tmp_path / "s.parquet")
+    assert info["name"] == "compressed"
+
+
+# ---------------------------------------------------------------------------
+# Parity vs the committed bpi2017 series (slow; needs the 135 MB local XES)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not (_BPI2017_XES.exists() and _BPI2017_PARQUET.exists()),
+    reason="needs local data/processed_logs/bpi2017.xes (not in CI)",
+)
+def test_parity_with_committed_bpi2017_series():
+    """The converter faithfully reproduces the committed bpi2017 series.
+
+    This is a *faithful port* of the external pmf-benchmark pipeline, not a byte-exact
+    re-run of it (the demo docstring is explicit that fidelity is not a correctness gate).
+    Two known, benign sources of divergence on the shared dates:
+
+      * Variant filter: upstream filtered harder (21 relations) than our ``0.0001``
+        threshold (28) — so the committed columns are a strict *subset* of ours, and a
+        few counts shift where a dropped rare variant fed a kept relation.
+      * pm4py version drift since the committed parquet was generated externally.
+
+    So we assert the load-bearing properties — same date span, committed feature space
+    ⊆ ours, and high numerical agreement on the shared cells — not literal equality.
+    """
+    produced = log_to_df_series(_BPI2017_XES)
+    committed = pd.read_parquet(_BPI2017_PARQUET)
+
+    # Normalise both indices to tz-naive daily timestamps for alignment.
+    produced.index = pd.to_datetime(produced.index).tz_localize(None).normalize()
+    cidx = pd.to_datetime(committed.index)
+    committed.index = (
+        cidx.tz_convert("UTC").tz_localize(None) if cidx.tz is not None else cidx.tz_localize(None)
+    ).normalize()
+
+    # Same date span, and every relation the committed series tracks is also produced.
+    assert committed.index.isin(produced.index).all()
+    assert committed.columns.isin(produced.columns).all()
+
+    common_dates = produced.index.intersection(committed.index)
+    common_cols = committed.columns
+    a = produced.loc[common_dates, common_cols].sort_index(axis=1)
+    b = committed.loc[common_dates, common_cols].sort_index(axis=1)
+
+    exact_fraction = (a == b).to_numpy().mean()
+    rel_mass_diff = (a - b).abs().to_numpy().sum() / b.to_numpy().sum()
+    assert exact_fraction >= 0.95, f"only {exact_fraction:.3f} of cells match exactly"
+    assert rel_mass_diff < 0.02, f"relative count divergence {rel_mass_diff:.4f} too high"
+
+
+# ---------------------------------------------------------------------------
+# Drift guard: the core and demo converters must stay byte-identical
+# ---------------------------------------------------------------------------
+
+
+def test_core_and_demo_converters_are_identical():
+    """The demo keeps a standalone ``pmf_tsfm``-free copy; pin the two converter bodies.
+
+    If this fails, a change landed in one copy but not the other — sync them.
+    """
+    demo_dir = str(_REPO_ROOT / "demo")
+    if demo_dir not in sys.path:
+        sys.path.insert(0, demo_dir)
+    import log_to_series as demo
+
+    from pmf_tsfm.data import log_to_series as core
+
+    for fn in ("event_df_to_series", "log_to_df_series"):
+        assert inspect.getsource(getattr(core, fn)) == inspect.getsource(getattr(demo, fn)), (
+            f"{fn} diverged between core and demo copies"
+        )


### PR DESCRIPTION
## What

Builds the **shared core seam** (issue #132) that the dev-ready MCP (#133) and Docker (#134) tracks depend on — an agent-clean, Gradio-free API over the *real* `src/pmf_tsfm` pipeline, plus an XES→time-series bridge so users can bring a raw `.xes` log. This is a **gate**: it lands on `main` before those two tracks fork (they `import pmf_tsfm.api`).

## Changes

- **`src/pmf_tsfm/data/log_to_series.py`** — lifts the demo's XES→daily-DF-relation converter into the core (`pm4py` lazy, `DatetimeIndex` retained, columns `"A -> B"` with ▶/■ markers). Adds `prepare_series_from_log()`: writes the series parquet, derives the 60/20/20 split indices, and stages the XES for Entropic Relevance.
- **`src/pmf_tsfm/api.py`** — `list_models()`, `forecast_only()`, `forecast_backtest()`. Compose the existing Hydra `inference` config and call `run_inference` → `evaluate_single` → `run_er_evaluation` — **no reimplementation**, so the numbers match the paper/CLI. Import-light (no model lib / Gradio / CUDA at import). Accepts `.xes`/`.xes.gz` (auto-converted) and prepared `.parquet` (parquet-only → `er=None`).

**Scope** (locked, ADR-0004): zero-shot holdout backtest only — no training. MAE/RMSE + ER. Chronos-2 tracer bullet; widening to Moirai/TimesFM is Phase 3.

Returns: `{predictions_path, quantiles_path, metrics:{mae,mae_std,rmse,rmse_std,er|None}|None, feature_names, n_windows, model, horizon}`.

## Gotchas handled (found during exploration)

1. `evaluate_single` returns nested `summary.MAE_mean/...` → mapped to flat `mae/rmse`.
2. The inference config makes `cfg.task` a *node*, but `run_er_evaluation` joins it into a path expecting a *string* → the ER cfg is fully resolved and `task` coerced to `"zero_shot"`. Regression-guarded by a test.
3. `model=chronos/chronos2` resolves to `cfg.model.name == "chronos_2"` (underscore) — used consistently for filenames/evaluate/ER.

## Verification

- **Full suite green:** 356 passed, 23 skipped (pre-existing), ruff lint + format clean.
- **Genuine Chronos-2 tracer bullet** (real model, bundled sepsis, no mocks): 86 windows, `mae=0.098`, `rmse=0.136`, `er=29.84`, saved to `outputs/er/zero_shot/sepsis/chronos_2/` — real pipeline numbers.
- Tests: ported converter unit tests against the core copy, `prepare_series_from_log` contract, bpi2017 parity, a **drift guard** pinning the core and demo converters byte-identical, api wiring via a mock adapter (no weights), and a slow file-gated real Chronos-2 run.

### Deviation from the handoff (deliberate, documented)

The bpi2017 parity asserts **faithful reproduction** (committed feature space ⊆ ours; 98.3% exact / 99.1%-by-mass agreement on shared cells), not byte-exact equality. The committed parquet was produced by the *external* pmf-benchmark repo with a harder variant filter (21 vs our 28 relations); the converter docstring already states fidelity is not a correctness gate. Measured before deciding.

Closes #132.