### PR TITLE
feat(docker): self-host image for the core forecasting pipeline (#134)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,90 @@
+# syntax=docker/dockerfile:1
+
+# =============================================================================
+# pmf-tsfm — self-host image for the core forecasting pipeline (issue #134)
+#
+# Build context = REPO ROOT:
+#     docker build -f docker/Dockerfile -t pmf-tsfm .
+#
+# Default image = Chronos + Moirai (both are regular deps). TimesFM is opt-in
+# (fragile/large GitHub-pinned zip, needs python >= 3.11):
+#     docker build -f docker/Dockerfile --build-arg INSTALL_TIMESFM=1 -t pmf-tsfm:timesfm .
+#
+# Built with uv (NOT pip): the [tool.uv] override-dependencies = ["torch>=2.8.0"]
+# in pyproject.toml resolves the uni2ts<->chronos numpy/torch clash, and that
+# resolution only holds under uv + uv.lock. Plain pip silently breaks it.
+# =============================================================================
+
+# ---- Builder: resolve + install the locked env into /app/.venv via uv --------
+FROM python:3.12-slim AS builder
+
+# uv binary from its official distroless image.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+WORKDIR /app
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+# TimesFM opt-in: 0 (default) = Chronos + Moirai only; 1 = add the timesfm_v25 extra.
+ARG INSTALL_TIMESFM=0
+
+# Step 1 — dependencies only (no project). Cached unless pyproject/uv.lock change.
+# .python-version (3.12) pins the interpreter uv resolves against to the system one.
+COPY pyproject.toml uv.lock .python-version ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project \
+      $( [ "$INSTALL_TIMESFM" = "1" ] && echo "--extra timesfm_v25" )
+
+# Step 2 — bring in source + configs, then editable-install the project.
+# Editable install is REQUIRED: api.py and the Hydra @hydra.main decorators resolve
+# configs/ RELATIVE TO THE MODULE FILE (parents[2] / "configs", ../../configs). So
+# src/ must live at /app/src and configs/ at /app/configs at runtime — a non-editable
+# copy into site-packages would break config resolution. README.md is needed because
+# pyproject sets readme = "README.md" (hatchling reads it when building the project).
+COPY README.md ./README.md
+COPY src/ ./src/
+COPY configs/ ./configs/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev \
+      $( [ "$INSTALL_TIMESFM" = "1" ] && echo "--extra timesfm_v25" )
+
+# ---- Runtime: slim image with graphviz + the prebuilt venv -------------------
+FROM python:3.12-slim
+
+# graphviz: DFG / Entropic-Relevance rendering (mirrors demo/packages.txt).
+# tini: a real PID-1 init. Without it python runs as PID 1, so os.getppid()==0 and
+# pm4py's import-time psutil.Process(getppid()) raises NoSuchProcess. tini gives the
+# python process a valid parent (PID 1 = tini), so pm4py imports cleanly.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends graphviz ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy the whole /app (venv + src + configs + pyproject) at the SAME path so the
+# editable install's .pth -> /app/src keeps resolving.
+COPY --from=builder /app /app
+
+# Docker-only launcher + thin backtest CLI (kept out of the package).
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY docker/backtest_cli.py /app/docker/backtest_cli.py
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Weight caches, unified under /cache so ONE volume persists every model family:
+#   HF_HOME          -> HF-hub models (chronos bolt_*, moirai/*, timesfm/*)
+#   XGD_CACHE_HOME    -> Chronos-2, which loads from s3://autogluon/chronos-2/ and
+#                        caches to $XGD_CACHE_HOME/chronos/ (note: the chronos lib
+#                        literally reads the misspelled "XGD_CACHE_HOME", not XDG).
+ENV PATH="/app/.venv/bin:$PATH" \
+    HF_HOME=/cache/huggingface \
+    XGD_CACHE_HOME=/cache \
+    PYTHONUNBUFFERED=1 \
+    PMF_DEVICE=cpu \
+    PMF_OUTPUT=/work/outputs
+
+# Mount a volume over /cache to persist weights across runs; /work/outputs for artifacts.
+VOLUME ["/cache", "/work/outputs"]
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+CMD ["list-models"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,35 @@
+# Build-context ignore for `docker build -f docker/Dockerfile .` (context = repo root).
+#
+# BuildKit honours `<dockerfile-path>.dockerignore` (this file) in preference to a
+# context-root `.dockerignore`, so the ignore rules live in docker/ with the Dockerfile.
+# Patterns are relative to the build context (the repo root).
+
+# Heavy / irrelevant data — sepsis & co. are MOUNTED (-v $PWD/data:/data), not baked in.
+data/
+outputs/
+results/
+wandb/
+
+# Other tracks — not part of the core image.
+demo/
+slides/
+manuscript/
+notebooks/
+
+# Dev cruft.
+.venv/
+.git/
+.github/
+.idea/
+.vscode/
+**/__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.DS_Store
+HANDOFF_*.md
+
+# Kept (NOT ignored), for reference: src/, configs/, docker/, pyproject.toml,
+# uv.lock, .python-version, README.md

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,127 @@
+# pmf-tsfm — self-host Docker image
+
+Run the **core** Process Model Forecasting pipeline (zero-shot directly-follows forecasting with
+Time Series Foundation Models) on **your own** process logs, with no caps. This is the BYO-data
+counterpart to the capped Gradio demo: same pipeline, same numbers as the paper/CLI.
+
+The image bundles `pmf_tsfm.api` (the Gradio-free seam), the Hydra CLIs, and a thin `backtest`
+command. Default models are **Chronos** and **Moirai**; **TimesFM** is an opt-in build.
+
+## Build
+
+The build context is the **repo root** and the Dockerfile lives in `docker/`:
+
+```bash
+docker build -f docker/Dockerfile -t pmf-tsfm .
+```
+
+This produces the default **Chronos + Moirai** image (fast — both are regular dependencies).
+
+> **Why uv, not pip.** The build uses `uv sync --frozen` against `uv.lock`. The
+> `[tool.uv] override-dependencies = ["torch>=2.8.0"]` in `pyproject.toml` resolves the
+> `uni2ts` ↔ `chronos` numpy/torch conflict (uni2ts pins `torch<2.5`, which is overly
+> conservative). That resolution **only holds under uv** — a plain `pip install` silently
+> reintroduces a numpy/torch clash. Don't swap in pip.
+
+### TimesFM (opt-in)
+
+TimesFM v2.5 is a large, GitHub-pinned zip (no PyPI release) and needs Python ≥ 3.11. It is **not**
+in the default image. To include it:
+
+```bash
+docker build -f docker/Dockerfile --build-arg INSTALL_TIMESFM=1 -t pmf-tsfm:timesfm .
+```
+
+This adds the `timesfm_v25` extra and unlocks `--model timesfm/2_5_200m` (and the other
+`timesfm/*` groups). Expect a longer, more fragile build.
+
+## Quick start — `backtest` (BYO data)
+
+Zero-shot holdout backtest on your own log. A raw `.xes`/`.xes.gz` is auto-converted to the daily
+DF-relation series (and used for Entropic Relevance); a prepared DF-relation `.parquet` is used
+as-is. The natural 60/20/20 split holds out the tail and the pipeline forecasts + scores it.
+
+```bash
+docker run --rm \
+  -v "$PWD/data:/data" \
+  -v pmf-cache:/cache \
+  -v "$PWD/outputs:/work/outputs" \
+  pmf-tsfm backtest --input /data/processed_logs/sepsis.xes --model chronos/chronos2
+```
+
+Prints a forecast summary plus **MAE / RMSE / Entropic Relevance**, e.g.:
+
+```
+── pmf-tsfm backtest ─────────────────────────────────────────
+  input        : /data/processed_logs/sepsis.xes
+  model        : chronos2
+  horizon      : 7 day(s)
+  windows      : ...
+  DF relations : ...
+── metrics (zero-shot holdout) ───────────────────────────────
+  MAE          : 0.xxxx ± 0.xxxx
+  RMSE         : 0.xxxx ± 0.xxxx
+  Entropic Rel.: 0.xxxx
+── artifacts ─────────────────────────────────────────────────
+  predictions  : /work/outputs/.../<log>_<model>_predictions.npy
+  quantiles    : /work/outputs/.../<log>_<model>_quantiles.npy
+──────────────────────────────────────────────────────────────
+```
+
+`backtest` flags: `--input` (required), `--model` (default `chronos/chronos2`), `--horizon`
+(default 7), `--device` (`cpu`/`cuda`/`mps`), `--train-end`/`--val-end` (override the split),
+`--no-er` (skip Entropic Relevance), `--output` (artifact dir, default `/work/outputs`),
+`--json` (machine-readable output). List the model groups with `docker run --rm pmf-tsfm list-models`.
+
+> **Cold start.** Chronos-2 weights download on first run from `s3://autogluon/chronos-2/`
+> (needs network; `boto3` is bundled) — a few minutes. Mount the `pmf-cache` volume (below) so the
+> weights persist and later runs skip the download. The image unifies every model family's cache
+> under `/cache` (`HF_HOME=/cache/huggingface` for HF-hub models; `XGD_CACHE_HOME=/cache` →
+> `/cache/chronos/...` for Chronos-2's S3 weights), so a single `-v pmf-cache:/cache` covers all of
+> them. ER rendering uses `graphviz` (installed in the image).
+
+## Hydra CLIs
+
+The full research entrypoints are dispatched by the first argument; remaining args are Hydra
+overrides:
+
+```bash
+docker run --rm -v "$PWD/data:/data" -v pmf-cache:/cache \
+  pmf-tsfm inference data=bpi2017 model=chronos/chronos2 device=cpu
+```
+
+Available commands: `inference`, `evaluate`, `evaluate_er`, `preprocess`, `train`, plus
+`list-models`, `help`, and `mcp` (see below). Dataset IDs are lowercase (`bpi2017`, `bpi2019_1`,
+`sepsis`, `hospital_billing`).
+
+## Volumes
+
+| Mount | Purpose |
+| --- | --- |
+| `-v "$PWD/data:/data"` | Your input logs (XES / parquet). The repo's bundled logs are **not** baked into the image. |
+| `-v pmf-cache:/cache` | Model-weight cache for all families (`HF_HOME=/cache/huggingface` + Chronos-2's `/cache/chronos`). Persists downloads across runs. |
+| `-v "$PWD/outputs:/work/outputs"` | Run artifacts (predictions, quantiles, metrics). |
+| `-v "$PWD/configs/data:/app/configs/data"` | Optional: drop in a custom `configs/data/<mylog>.yaml` for the Hydra path. |
+
+## CPU vs GPU
+
+The image defaults to **CPU** (`PMF_DEVICE=cpu`). The default image ships the CPU torch build, so
+GPU requires either a CUDA-torch variant or building on an `nvidia/cuda` base. Once you have a
+GPU-capable image, run with the NVIDIA runtime and select the device:
+
+```bash
+docker run --rm --gpus all -v "$PWD/data:/data" -v pmf-cache:/cache \
+  pmf-tsfm backtest --input /data/processed_logs/sepsis.xes --model chronos/chronos2 --device cuda
+```
+
+## Models
+
+- **Chronos** (default): `chronos/chronos2`, `chronos/bolt_{tiny,mini,small,base}`
+- **Moirai** (default): `moirai/{1_1_small,1_1_base,1_1_large,2_0_small,moe_base}`
+- **TimesFM** (opt-in, `INSTALL_TIMESFM=1`): `timesfm/{1_0_200m,2_0_500m,2_5_200m}`
+
+## MCP
+
+`docker run pmf-tsfm mcp` launches the FastMCP server — but only once the **MCP track (#133,
+`mcp/server.py`)** is merged and the image is rebuilt. Until then the arm is wired and exits with a
+clear message; it is not bundled.

--- a/docker/backtest_cli.py
+++ b/docker/backtest_cli.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+"""Thin argparse CLI over ``pmf_tsfm.api.forecast_backtest`` for the Docker image (#134).
+
+Docker-only shim — kept out of the core package so ``src/`` stays import-clean. It does
+**not** reimplement anything: it calls ``forecast_backtest`` (the same composed Hydra
+pipeline the CLI runs), so the printed numbers match the paper/CLI.
+
+    backtest --input /data/processed_logs/sepsis.xes --model chronos/chronos2 --horizon 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="backtest",
+        description="Zero-shot holdout backtest on your own process log (XES or DF-relation parquet).",
+    )
+    p.add_argument(
+        "--input",
+        required=True,
+        help="Raw .xes/.xes.gz log (auto-converted to the daily DF-relation series) or a prepared .parquet.",
+    )
+    p.add_argument(
+        "--model",
+        default="chronos/chronos2",
+        help="Model config group, e.g. chronos/chronos2, moirai/2_0_small (run `list-models` to see all).",
+    )
+    p.add_argument(
+        "--horizon", type=int, default=7, help="Forecast / holdout length in days (default: 7)."
+    )
+    p.add_argument(
+        "--device",
+        default=os.environ.get("PMF_DEVICE", "cpu"),
+        help="cpu | cuda | mps (falls back to cpu if unavailable). Default: $PMF_DEVICE or cpu.",
+    )
+    p.add_argument(
+        "--train-end", type=int, default=None, help="Override the derived 60%% split index."
+    )
+    p.add_argument(
+        "--val-end", type=int, default=None, help="Override the derived 80%% split index."
+    )
+    p.add_argument(
+        "--no-er",
+        action="store_true",
+        help="Skip Entropic Relevance (ER is only computable for .xes input anyway).",
+    )
+    p.add_argument(
+        "--output",
+        default=os.environ.get("PMF_OUTPUT", "/work/outputs"),
+        help="Run/artifact dir (mount a volume to keep predictions). Default: $PMF_OUTPUT or /work/outputs.",
+    )
+    p.add_argument("--json", action="store_true", help="Print the raw result dict as JSON only.")
+    return p
+
+
+def _fmt(mean: float | None, std: float | None) -> str:
+    if mean is None:
+        return "n/a"
+    return f"{mean:.4f} ± {std:.4f}" if std is not None else f"{mean:.4f}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"error: input not found: {input_path}", file=sys.stderr)
+        print('       mount your data, e.g. -v "$PWD/data:/data"', file=sys.stderr)
+        return 1
+
+    Path(args.output).mkdir(parents=True, exist_ok=True)
+
+    # Imported here so --help stays instant and no model library loads on an arg error.
+    from pmf_tsfm.api import forecast_backtest
+
+    result = forecast_backtest(
+        input_path=input_path,
+        model=args.model,
+        horizon=args.horizon,
+        device=args.device,
+        train_end=args.train_end,
+        val_end=args.val_end,
+        workdir=args.output,
+        compute_er=not args.no_er,
+    )
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    m = result.get("metrics") or {}
+    n_feat = len(result["feature_names"]) if result.get("feature_names") else "?"
+    er = m.get("er")
+
+    print("── pmf-tsfm backtest ─────────────────────────────────────────")
+    print(f"  input        : {input_path}")
+    print(f"  model        : {result['model']}")
+    print(f"  horizon      : {result['horizon']} day(s)")
+    print(f"  windows      : {result['n_windows']}")
+    print(f"  DF relations : {n_feat}")
+    print("── metrics (zero-shot holdout) ───────────────────────────────")
+    print(f"  MAE          : {_fmt(m.get('mae'), m.get('mae_std'))}")
+    print(f"  RMSE         : {_fmt(m.get('rmse'), m.get('rmse_std'))}")
+    if er is not None:
+        print(f"  Entropic Rel.: {er:.4f}")
+    else:
+        print("  Entropic Rel.: n/a (parquet input or --no-er)")
+    print("── artifacts ─────────────────────────────────────────────────")
+    print(f"  predictions  : {result['predictions_path']}")
+    print(f"  quantiles    : {result['quantiles_path']}")
+    print("──────────────────────────────────────────────────────────────")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Dispatch table for the pmf-tsfm self-host image (issue #134).
+# The first argument selects the surface; everything after it passes through.
+set -euo pipefail
+
+cmd="${1:-list-models}"
+shift || true
+
+case "$cmd" in
+  backtest)
+    # Thin argparse CLI over pmf_tsfm.api.forecast_backtest (BYO-data happy path).
+    exec python /app/docker/backtest_cli.py "$@"
+    ;;
+  inference)
+    exec python -m pmf_tsfm.inference "$@"
+    ;;
+  train)
+    exec python -m pmf_tsfm.train "$@"
+    ;;
+  evaluate)
+    exec python -m pmf_tsfm.evaluate "$@"
+    ;;
+  evaluate_er)
+    exec python -m pmf_tsfm.er.evaluate_er "$@"
+    ;;
+  preprocess)
+    # Module lives under data/ — note the `data.` prefix.
+    exec python -m pmf_tsfm.data.preprocess "$@"
+    ;;
+  mcp)
+    # The MCP server ships with the #133 track (mcp/server.py); guard until it lands.
+    if python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('mcp.server') else 1)"; then
+      exec python -m mcp.server "$@"
+    fi
+    echo "error: the 'mcp' server is not bundled in this image." >&2
+    echo "       It ships with the MCP track (#133, mcp/server.py); rebuild once that merges." >&2
+    exit 2
+    ;;
+  list-models)
+    exec python -c "from pmf_tsfm.api import list_models; print('\n'.join(list_models()))"
+    ;;
+  -h | --help | help)
+    cat >&2 <<'EOF'
+pmf-tsfm — self-host image for the core forecasting pipeline.
+
+Usage: docker run [docker opts] pmf-tsfm <command> [args]
+
+Commands:
+  backtest --input <log.xes|.parquet> [--model chronos/chronos2] [--horizon 7] [--device cpu]
+                        Zero-shot holdout backtest on your own log; prints forecast + MAE/RMSE/ER.
+  inference    <hydra overrides>   Run the Hydra inference CLI (python -m pmf_tsfm.inference).
+  evaluate     <hydra overrides>   Run the evaluation CLI.
+  evaluate_er  <hydra overrides>   Run the Entropic Relevance CLI.
+  preprocess   <hydra overrides>   Run the preprocessing CLI.
+  train        <hydra overrides>   Run the training CLI (LoRA / full fine-tune).
+  list-models                      List available model config groups.
+  mcp                              Launch the FastMCP server (requires the #133 mcp/ track).
+
+Examples:
+  docker run -v "$PWD/data:/data" -v pmf-hf-cache:/cache/huggingface pmf-tsfm \
+    backtest --input /data/processed_logs/sepsis.xes --model chronos/chronos2
+  docker run pmf-tsfm inference data=bpi2017 model=chronos/chronos2 device=cpu
+EOF
+    exit 2
+    ;;
+  *)
+    echo "error: unknown command '$cmd'" >&2
+    echo "       try: backtest, inference, evaluate, evaluate_er, preprocess, train, list-models, mcp, help" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Closes #134.

Packages the core `pmf_tsfm` pipeline as a uv-built, multi-stage Docker image so others can run **zero-shot DF-relation forecasting on their own process logs with no caps** — the BYO-data counterpart to the capped Gradio demo. The image serves the Gradio-free `pmf_tsfm.api` seam (#132) plus the Hydra CLIs. New top-level `docker/` folder; build context = repo root.

## What's in `docker/`
- **`Dockerfile`** — `python:3.12-slim` (matches the repo's `.python-version`), multi-stage. Builder runs `uv sync --frozen` (**not pip** — the `[tool.uv] override-dependencies = ["torch>=2.8.0"]` that resolves the `uni2ts`↔`chronos` numpy/torch clash only holds under uv); runtime copies the venv + `src/` + `configs/`. Default models **Chronos + Moirai**; **TimesFM opt-in** via `--build-arg INSTALL_TIMESFM=1` (the `timesfm_v25` extra). apt `graphviz` for DFG/ER; **tini** as PID 1.
- **`entrypoint.sh`** — first arg dispatches `backtest` / `inference` / `train` / `evaluate` / `evaluate_er` / `preprocess` / `mcp` (guarded until #133) / `list-models`.
- **`backtest_cli.py`** — thin argparse shim over `api.forecast_backtest`; prints forecast + MAE/RMSE/ER. No reimplementation, so numbers match the CLI/paper.
- **`Dockerfile.dockerignore`** — BuildKit per-Dockerfile ignore (context = repo root); excludes `data/`, `outputs/`, other tracks.
- **`README.md`** — BYO data, volumes, GPU path, TimesFM opt-in, uv-not-pip rationale.

Weight caches are unified under `/cache` (`HF_HOME=/cache/huggingface` for HF-hub models; `XGD_CACHE_HOME=/cache` → `/cache/chronos` for Chronos-2's `s3://autogluon/chronos-2/` weights), so a single `-v pmf-cache:/cache` volume persists every model family.

## Verification (default image, run locally)
| Criterion | Result |
| --- | --- |
| `docker build` (default Chronos+Moirai) | ✅ image 2.9 GB, built with uv (no pip) |
| uv resolves chronos + moirai, no numpy clash | ✅ numpy 1.26.4, torch 2.8.0+cpu, `import chronos, uni2ts` clean |
| `backtest` on bundled sepsis | ✅ MAE 0.0977±0.1898 · RMSE 0.1361±0.2227 · ER 29.84 (86 windows, 140 DF relations) |
| `inference` Hydra path | ✅ dispatch + config compose + override passthrough |
| Weight cache persists across runs | ✅ cold load 214.7 s → warm 0.0 s with `-v pmf-cache:/cache` |
| README coverage | ✅ |

TimesFM (`--build-arg INSTALL_TIMESFM=1`) is wired + documented but **not run** here — default-only verify keeps the build fast for the deadline.

### Fixed during verification (baked into the image)
- pm4py crashed on import as PID 1 (`psutil.Process(getppid())`, ppid 0) → added **tini** as init.
- Chronos-2 ignores `HF_HOME` (uses `XGD_CACHE_HOME` → `~/.cache/chronos`) → unified caches under `/cache`.

The `mcp` arm is wired but guarded; Docker's MCP path is finalized once #133 (`mcp/server.py`) lands.