### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmf-tsfm"
-version = "0.1.0"
+version = "0.2.0"
 description = "Process Mining Forecasting with Time Series Foundation Models"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -3804,7 +3804,7 @@ wheels = [
 
 [[package]]
 name = "pmf-tsfm"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Bumps `pyproject.toml` + `uv.lock` to **0.2.0** to mark the core MCP/Docker/api delivery (everything on main since the demo-only `v0.1.0`).

After merge: tag `v0.2.0` on main and publish the GitHub Release (with the v0.1.0 backfill).

Minor bump — new backward-compatible features (#132 api seam, #133 MCP, #134 Docker, #135 ADR-0008, #136 demo GUI-only).