### PR TITLE
docs: refresh README + MCP agent setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Systematic evaluation of Time Series Foundation Models (TSFMs) for Process Model
 - Zero-shot coverage: 12 TSFM variants across Chronos, Moirai, and TimesFM.
 - Fine-tuning coverage: LoRA for Chronos-Bolt and Moirai-1.1; full fine-tuning for Chronos-Bolt, Chronos-2, and Moirai-1.1.
 - Data assets: daily DF-count time series in Parquet and XES logs for Entropic Relevance evaluation.
-- Outputs: predictions under `outputs/{task}/{dataset}/{model}/` and checkpoints/adapters under `results/{task}/{dataset}/{model}/`.
 - Orchestration: [Hydra](https://hydra.cc/)-driven Python entry points plus local orchestration scripts and [VSC](https://www.vscentrum.be/) HPC helpers.
+- Self-host & agents: run zero-shot forecasting on your own log via the [Docker image](docker/README.md) or the headless [MCP server](mcp/README.md).
 
 ## Supported Models
 
@@ -148,6 +148,8 @@ python -m pmf_tsfm.er.evaluate_er model=chronos/bolt_small data=bpi2017
 
 Add `logger=wandb` or `logger=wandb_offline` to any Hydra command if you want W&B tracking.
 
+Predictions are written under `outputs/{task}/{dataset}/{model}/` and fine-tuned checkpoints / LoRA adapters under `results/{task}/{dataset}/{model}/`. Both directories are generated per run and git-ignored.
+
 ## Common Workflows
 
 All experiment entry points are [Hydra](https://hydra.cc/)-based.
@@ -258,25 +260,6 @@ The capped Gradio demo in `demo/` remains the hosted visualization Space; these 
 
 For macOS with MPS, keep `training.num_workers=0`. For Linux systems with NVIDIA GPUs and for the HPC cluster, higher worker counts such as `training.num_workers=4` are the intended path.
 
-## Project Structure
-
-```text
-pmf-tsfm/
-├── src/pmf_tsfm/       # Python package: model adapters, data modules, evaluation, api.py seam
-├── configs/            # Hydra configs for tasks, models, datasets, loggers, paths
-├── scripts/            # Local orchestration scripts and HPC helpers
-├── docker/             # Self-host image for the core pipeline (see docker/README.md)
-├── mcp/                # Headless FastMCP server over the api.py seam (see mcp/README.md)
-├── demo/               # Gradio forecast explorer, hosted as a live HF Space (see demo/README.md)
-├── tests/              # pytest suite
-├── data/               # Zenodo assets plus generated processed splits
-├── outputs/            # Saved predictions and evaluation artifacts
-├── results/            # Checkpoints and LoRA adapters
-├── notebooks/          # Analysis notebooks
-├── manuscript/         # Paper assets
-└── slides/             # Slidev talk deck, published as a live HF Space
-```
-
 ## HPC (VSC wICE cluster)
 
 [Slurm](https://slurm.schedmd.com/) submission scripts for the [VSC](https://www.vscentrum.be/) wICE cluster live under `scripts/hpc/`. Use `scripts/hpc/.env.hpc.example` as the cluster-specific starting point.
@@ -294,6 +277,25 @@ LOGGER=wandb bash scripts/hpc/submit_pipeline.sh
 LOGGER=wandb_offline bash scripts/hpc/submit_pipeline.sh
 bash scripts/hpc/submit_zero_shot.sh   # Default: LOGGER=wandb for direct stage runs
 bash scripts/hpc/sync_wandb_offline.sh # Only after explicit offline runs
+```
+
+## Project Structure
+
+```text
+pmf-tsfm/
+├── src/pmf_tsfm/       # Python package: model adapters, data modules, evaluation, api.py seam
+├── configs/            # Hydra configs for tasks, models, datasets, loggers, paths
+├── scripts/            # Local orchestration scripts and HPC helpers
+├── docker/             # Self-host image for the core pipeline (see docker/README.md)
+├── mcp/                # Headless FastMCP server over the api.py seam (see mcp/README.md)
+├── demo/               # Gradio forecast explorer, hosted as a live HF Space (see demo/README.md)
+├── tests/              # pytest suite
+├── data/               # Zenodo assets plus generated processed splits
+├── outputs/            # Generated predictions and evaluation artifacts (git-ignored)
+├── results/            # Generated checkpoints and LoRA adapters (git-ignored)
+├── notebooks/          # Analysis notebooks
+├── manuscript/         # Paper assets
+└── slides/             # Slidev talk deck, published as a live HF Space
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Systematic evaluation of Time Series Foundation Models (TSFMs) for Process Model
 
 ## At a Glance
 
-- Zero-shot coverage: 13 TSFM variants across Chronos, Moirai, and TimesFM.
+- Zero-shot coverage: 12 TSFM variants across Chronos, Moirai, and TimesFM.
 - Fine-tuning coverage: LoRA for Chronos-Bolt and Moirai-1.1; full fine-tuning for Chronos-Bolt, Chronos-2, and Moirai-1.1.
 - Data assets: daily DF-count time series in Parquet and XES logs for Entropic Relevance evaluation.
 - Outputs: predictions under `outputs/{task}/{dataset}/{model}/` and checkpoints/adapters under `results/{task}/{dataset}/{model}/`.
@@ -35,7 +35,7 @@ Systematic evaluation of Time Series Foundation Models (TSFMs) for Process Model
 | Family | Variants |
 |--------|----------|
 | **Chronos** | Bolt Tiny, Bolt Mini, Bolt Small, Bolt Base, Chronos-2 |
-| **Moirai** | 1.1 Small/Base/Large, 2.0 Small, MoE Base |
+| **Moirai** | 1.1 Small/Large, 2.0 Small, MoE Base |
 | **TimesFM** | 1.0-200M, 2.0-500M, 2.5-200M |
 
 - LoRA experiments in this repo cover `chronos/bolt_small`, `chronos/bolt_base`, `moirai/1_1_small`, and `moirai/1_1_large`.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@
 [![License](https://img.shields.io/badge/license-MIT-yellow.svg?style=flat-square&labelColor=2b3137)](https://opensource.org/licenses/MIT)
 [![arXiv](https://img.shields.io/badge/arXiv-2512.07624-b31b1b.svg?style=flat-square&labelColor=2b3137)](https://arxiv.org/abs/2512.07624)
 [![Dataset](https://img.shields.io/badge/dataset-Zenodo-007afc.svg?style=flat-square&logo=zenodo&logoColor=white&labelColor=2b3137)](https://zenodo.org/records/18327515)
+[![Demo](https://img.shields.io/badge/%F0%9F%A4%97%20demo-Space-ff9d00.svg?style=flat-square&labelColor=2b3137)](https://huggingface.co/spaces/YongboYu/pmf-tsfm-demo)
+[![Slides](https://img.shields.io/badge/%F0%9F%A4%97%20slides-Space-ffce00.svg?style=flat-square&labelColor=2b3137)](https://huggingface.co/spaces/YongboYu/pmf-tsfm-slides)
 
 </div>
 
 ---
 
 Systematic evaluation of Time Series Foundation Models (TSFMs) for Process Model Forecasting (PMF), predicting how directly-follows (DF) relations in a process evolve over time. The repository benchmarks Chronos, Moirai, and TimesFM across zero-shot, LoRA, and full fine-tuning settings on four real-world event logs, using MAE/RMSE alongside Entropic Relevance as a process-aware conformance metric.
+
+**Try it live:** an interactive [forecast explorer](https://huggingface.co/spaces/YongboYu/pmf-tsfm-demo) and the [talk slides](https://huggingface.co/spaces/YongboYu/pmf-tsfm-slides), both hosted as Hugging Face Spaces.
 
 ## At a Glance
 
@@ -258,16 +262,19 @@ For macOS with MPS, keep `training.num_workers=0`. For Linux systems with NVIDIA
 
 ```text
 pmf-tsfm/
-├── src/pmf_tsfm/       # Python package: model adapters, data modules, evaluation
+├── src/pmf_tsfm/       # Python package: model adapters, data modules, evaluation, api.py seam
 ├── configs/            # Hydra configs for tasks, models, datasets, loggers, paths
 ├── scripts/            # Local orchestration scripts and HPC helpers
+├── docker/             # Self-host image for the core pipeline (see docker/README.md)
+├── mcp/                # Headless FastMCP server over the api.py seam (see mcp/README.md)
+├── demo/               # Gradio forecast explorer, hosted as a live HF Space (see demo/README.md)
 ├── tests/              # pytest suite
 ├── data/               # Zenodo assets plus generated processed splits
 ├── outputs/            # Saved predictions and evaluation artifacts
 ├── results/            # Checkpoints and LoRA adapters
 ├── notebooks/          # Analysis notebooks
 ├── manuscript/         # Paper assets
-└── slides/             # Presentation materials
+└── slides/             # Slidev talk deck, published as a live HF Space
 ```
 
 ## HPC (VSC wICE cluster)

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ These are local orchestration scripts: shell helpers for running sequential expe
 
 ## Run on Your Own Data (Self-Host & Agents)
 
-Beyond the research CLI above, the core pipeline ships as two self-host artifacts so you can run zero-shot DF-relation forecasting plus accuracy (MAE / RMSE + Entropic Relevance) on **your own** process log — a raw `.xes`/`.xes.gz` (auto-converted to the daily DF-relation series) or a prepared DF-relation `.parquet` — with no caps. Both wrap the same Gradio-free seam [`src/pmf_tsfm/api.py`](src/pmf_tsfm/api.py) (`forecast_backtest` / `forecast_only` / `list_models`), a zero-shot holdout backtest (ADR-0004) that reuses the real cores, so the numbers match the CLI and paper. See [ADR-0008](docs/adr/0008-core-forecasting-artifacts-mcp-docker.md) for the design.
+Beyond the research CLI above, the core pipeline ships as two self-host artifacts so you can run zero-shot DF-relation forecasting plus accuracy (MAE / RMSE + Entropic Relevance) on **your own** process log — a raw `.xes`/`.xes.gz` (auto-converted to the daily DF-relation series) or a prepared DF-relation `.parquet` — with no caps. Both wrap the same Gradio-free seam [`src/pmf_tsfm/api.py`](src/pmf_tsfm/api.py) (`forecast_backtest` / `forecast_only` / `list_models`) — a zero-shot holdout backtest that reuses the real cores, so the numbers match the CLI and paper. See the per-artifact READMEs below for setup and design details.
 
 - **Docker — self-host CLI** ([`docker/README.md`](docker/README.md)). Build the core image and forecast your own log:
   ```bash

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,7 +8,25 @@ numbers match the paper/CLI. FastMCP auto-derives every tool's JSON schema from 
 docstring — there is **no hand-written schema**.
 
 This is *not* the Gradio-headless MCP surface in `demo/` (`gr.api(...)` + `launch(mcp_server=True)`,
-which serves GUI-shaped drift bundles). See **Why a dedicated server** below.
+which serves GUI-shaped drift bundles); it is a no-GUI service for agents and scripts.
+
+## Quick start
+
+This server is **repo-local** — not an `npx`/`uvx` registry drop-in. It wraps the `pmf_tsfm`
+package (the model cores + Hydra configs, run against *your* data), so there is no published
+one-liner: clone the repo, install the `mcp` extra, then point your agent at it.
+
+```bash
+git clone https://github.com/YongboYu/pmf-tsfm.git && cd pmf-tsfm
+uv sync --extra mcp
+# wire it into Claude Code (writes .mcp.json in the repo):
+claude mcp add pmf-tsfm --scope project \
+  -- uv run --directory "$PWD" --extra mcp python mcp/server.py
+```
+
+No-clone option: the [self-host Docker image](#run-via-the-self-host-docker-image) bundles the
+server (`docker run -i <image> mcp`). For Claude Desktop / custom-client configs and example
+prompts, see [Connect an agent / MCP client](#connect-an-agent--mcp-client).
 
 ## Tools
 
@@ -20,7 +38,7 @@ which serves GUI-shaped drift bundles). See **Why a dedicated server** below.
 
 `forecast_backtest` / `forecast_only` accept a raw `.xes`/`.xes.gz` log (auto-converted to the
 daily DF-relation series) or a prepared DF-relation `.parquet`. Scope is the locked zero-shot
-holdout backtest (ADR-0004): the natural 60/20/20 split holds out the tail and the existing
+holdout backtest: the natural 60/20/20 split holds out the tail and the existing
 expanding-window pipeline scores it (MAE/RMSE, plus Entropic Relevance when an XES log is given).
 
 ## Run locally
@@ -53,6 +71,71 @@ async def main():
 asyncio.run(main())
 ```
 
+## Connect an agent / MCP client
+
+The point of this server is to let an **agent** call forecasting as a tool. Any MCP host works —
+[Claude Code](https://docs.claude.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex),
+Claude Desktop, Cursor, and others, or a custom client over the `mcp` SDK. You register the launch
+command once; the three tools above then appear to the model with schemas auto-derived from their
+signatures.
+
+Pick a launch command that (a) runs in an environment where the `mcp` extra is installed and (b) has
+the **repo root as its working directory** — so `python mcp/server.py` keeps `sys.path[0]` at `mcp/`
+(see [Note on the folder name](#note-on-the-folder-name)) and relative `input_path`s resolve against
+your data. `uv run --directory` does both:
+
+**Claude Code** — add it as a project-scoped server (writes `.mcp.json`):
+
+```bash
+claude mcp add pmf-tsfm --scope project \
+  -- uv run --directory "$PWD" --extra mcp python mcp/server.py
+```
+
+or write `.mcp.json` at the repo root by hand:
+
+```json
+{
+  "mcpServers": {
+    "pmf-tsfm": {
+      "command": "uv",
+      "args": ["run", "--directory", "/abs/path/to/pmf-tsfm", "--extra", "mcp", "python", "mcp/server.py"]
+    }
+  }
+}
+```
+
+**Claude Desktop / Cursor / Cline / Windsurf** — the same `mcpServers` block in that host's config
+(`claude_desktop_config.json`, `.cursor/mcp.json`, …). Use the absolute `--directory` path when the
+host has no project working directory.
+
+**Codex CLI** — the same command/args, expressed as TOML in `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.pmf-tsfm]
+command = "uv"
+args = ["run", "--directory", "/abs/path/to/pmf-tsfm", "--extra", "mcp", "python", "mcp/server.py"]
+```
+
+Then just ask in natural language — the agent chooses the tools and fills the arguments:
+
+> "List the pmf-tsfm models, then backtest `data/processed_logs/sepsis.xes` with `chronos/chronos2`
+> and report the MAE and Entropic Relevance."
+
+A typical call sequence and what comes back:
+
+1. `list_models()` → `["chronos/chronos2", "moirai/2_0_small", ...]`
+2. `forecast_backtest(input_path="data/processed_logs/sepsis.xes", model="chronos/chronos2")`
+   → `{"metrics": {"mae": ..., "rmse": ..., "er": ...}, "predictions_path": ..., "n_windows": ..., ...}`
+
+Tips for agent use:
+
+- Pass **absolute `input_path`s** (or paths relative to the `--directory` root) — the server resolves
+  them against its own working directory, not the agent's.
+- Entropic Relevance (`er`) is only computed for `.xes`/`.xes.gz` input; for a `.parquet` series it
+  comes back `null` (set `compute_er=false` to skip it on XES too).
+- Use `forecast_only` when you want predictions without scoring — e.g. forecasting a genuine future
+  that has no held-out ground truth — and `device="cuda"`/`"mps"` to move off the CPU default.
+
 ## Run via the self-host Docker image
 
 The self-host image (#134) bundles this server; the `mcp` subcommand launches it over stdio:
@@ -63,13 +146,6 @@ docker run -i <image> mcp
 
 (The image installs the package with the `mcp` extra — `pip install .[mcp]` — and the entrypoint's
 `mcp` dispatch is owned by the Docker track.)
-
-## Why a dedicated server (not Gradio-headless)
-
-This is a no-GUI service. Pulling all of Gradio in to expose a few functions reintroduces the
-coupling the demo/core split removes and contradicts keeping `demo/` GUI-only. ADR-0003 rejected a
-standalone FastMCP server *only in the GUI-Space context*; the amendment that carves out this
-headless core server is **ADR-0008** (written under #135) — see `docs/adr/`.
 
 ## Note on the folder name
 


### PR DESCRIPTION
Documentation-only pass over the main README and the MCP artifact README, reflecting recent repo development and fixing references that went stale when the design docs moved local-only.

## Main README
- Drop broken links/citations to `docs/adr/` (now git-ignored / not public).
- Add 🤗 **demo** and **slides** Space badges + a "Try it live" pointer.
- List `docker/`, `mcp/`, `demo/` in Project Structure; note the `api.py` seam.
- Correct zero-shot coverage **13 → 12** to match the paper's MAE/RMSE tables (Moirai-1.1-base has a config but no result row); align the Supported Models table.
- Replace the output-path bullet in *At a Glance* with a **self-host & agents** bullet; move the path detail to a generated/git-ignored note after Quick Start.
- Regroup sections so Tested Environments → HPC stay together, with Project Structure after.

## MCP README (`mcp/README.md`)
- Add a **Quick start** (clarifies it's repo-local, not an `npx`/`uvx` drop-in).
- Add **Connect an agent / MCP client** — host-agnostic setup for Claude Code, **Codex CLI**, Claude Desktop, Cursor, … with example prompts and the tool-call flow.
- Remove the now-private `docs/adr` citations and the "Why a dedicated server" section.

No code changes.