### PR TITLE
fix(demo): pin torch==2.11.0 for ZeroGPU; guard it from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Guard rails for Dependabot's automatic security-update PRs.
+#
+# `open-pull-requests-limit: 0` keeps scheduled *version* updates off (we only take
+# Dependabot's security updates, as before adding this file); the `ignore` rules below
+# apply to security updates too.
+#
+# torch in demo/requirements.txt must stay on ZeroGPU's supported-version list
+# (currently 2.11.0/2.10.0/2.9.1/2.8.0): Dependabot bumping it to 2.12.0 (#150) took the
+# Space down with "torch version in requirements.txt is not compatible with ZeroGPU".
+# Any torch bump there has to be done by hand against that list.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/demo"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "torch"

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -19,6 +19,9 @@ pandas>=2.2.3,<3  # pm4py's pandas backend isn't pandas-3 ready: pandas 3's pyar
                  # string columns break pm4py variant filtering ("is_in has no kernel for
                  # list<string>"), which the live path hits during preprocessing.
 pm4py>=2.7.12.4
-torch>=2.12.0
+torch==2.11.0  # ZeroGPU only accepts specific torch versions (2.11.0/2.10.0/2.9.1/2.8.0);
+                # anything newer makes the Space fail with a configuration error. Keep this
+                # exact pin on ZeroGPU's supported list — Dependabot is told to leave it
+                # alone in .github/dependabot.yml.
 chronos-forecasting>=1.4.0
 boto3>=1.28  # Chronos-2 loads from an s3:// checkpoint (configs/model/chronos/chronos2.yaml)


### PR DESCRIPTION
## Problem

The Space ([YongboYu/pmf-tsfm-demo](https://huggingface.co/spaces/YongboYu/pmf-tsfm-demo)) is down with:

> **Configuration error** — torch version in requirements.txt is not compatible with ZeroGPU. Supported versions: 2.11.0, 2.10.0, 2.9.1, 2.8.0

Cause: Dependabot's security bump of torch 2.8.0 → 2.12.0 in `demo/requirements.txt` (#150) was auto-deployed by `deploy-demo.yml`, and ZeroGPU rejects torch ≥ 2.12.

## Fix

- Pin `torch==2.11.0` (newest ZeroGPU-supported version) in `demo/requirements.txt`.
- Add `.github/dependabot.yml` that ignores torch for the `/demo` pip ecosystem (with `open-pull-requests-limit: 0` so no scheduled version-update PRs start; security updates for everything else continue as before). Any future torch bump must be done by hand against ZeroGPU's supported list.

Merging auto-redeploys the Space via `deploy-demo.yml`.