### PR TITLE
chore(deps): override python-dotenv to >=1.2.2 (symlink-following fix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,13 @@ precision = 2
 # uni2ts declares torch<2.5 but works fine with newer torch at runtime.
 # This override keeps torch at the version we deliberately bumped to, rather
 # than letting uni2ts downgrade it.
+#
+# python-dotenv: uni2ts also hard-pins python-dotenv==1.0.0, which carries a
+# symlink-following vulnerability in set_key (Dependabot alert; #87). Override
+# to the patched release — dotenv's 1.x API is stable and uni2ts only reads
+# .env files through it.
 [tool.uv]
 override-dependencies = [
     "torch>=2.8.0",
+    "python-dotenv>=1.2.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,10 @@ resolution-markers = [
 ]
 
 [manifest]
-overrides = [{ name = "torch", specifier = ">=2.8.0" }]
+overrides = [
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "torch", specifier = ">=2.8.0" },
+]
 
 [[package]]
 name = "absl-py"
@@ -4510,11 +4513,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.0"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/06/1ef763af20d0572c032fa22882cfbfb005fba6e7300715a37840858c919e/python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba", size = 37399, upload-time = "2023-02-24T06:46:37.282Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/2f/62ea1c8b593f4e093cc1a7768f0d46112107e790c3e478532329e434f00b/python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a", size = 19482, upload-time = "2023-02-24T06:46:36.009Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope

Group **B** of #85 — clears the `python-dotenv` `set_key` symlink-following Dependabot alert (vulnerable `< 1.2.2`).

## Approach

`python-dotenv` is only a transitive dependency here, and **uni2ts hard-pins `python-dotenv==1.0.0`**, so the planned pyproject bump / `constraint-dependencies` route is unsatisfiable. Instead this uses the `[tool.uv] override-dependencies` escape hatch the project already uses for uni2ts's stale `torch<2.5` pin — same pattern, same justification: dotenv's 1.x API is stable and uni2ts only reads `.env` files through it.

## Verification

- `uv lock --upgrade-package python-dotenv` resolves; lock now has `python-dotenv 1.2.2`.
- `uv run pytest`: **347 passed, 21 skipped**.
- The Dependabot alert should auto-resolve after merge.

Closes #87