### PR TITLE
feat(export): add HF results normalizer (pmf-export-results)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,6 +213,7 @@ __marimo__/
 # Generated outputs and results
 outputs/
 results/
+data/exports/
 
 # uv
 .python-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ mcp = ["mcp>=1.2"]
 
 [project.scripts]
 pmf-inference = "pmf_tsfm.inference:main"
+pmf-export-results = "pmf_tsfm.export.hf_results:main"
 
 # [project.urls]
 # Repository = "https://github.com/YongboYu/pmf-tsfm"

--- a/src/pmf_tsfm/export/__init__.py
+++ b/src/pmf_tsfm/export/__init__.py
@@ -1,0 +1,1 @@
+"""Exporters that package pmf-tsfm artifacts for release (e.g. the HF results Dataset)."""

--- a/src/pmf_tsfm/export/hf_results.py
+++ b/src/pmf_tsfm/export/hf_results.py
@@ -1,0 +1,404 @@
+"""Normalize the nested ``outputs/`` result tree into one long-format table.
+
+The experiment results live as nested per-(task, dataset, model) JSON:
+
+    outputs/{task}/{DATASET}/{model}/{DATASET}_{model}_metrics.json    # summary + per_feature
+    outputs/{task}/{DATASET}/{model}/{DATASET}_{model}_metadata.json   # run context
+    outputs/er/{task}/{DATASET}/{model}/{DATASET}_{model}_er.json      # ER summary + per-window
+    outputs/er/{task}/{DATASET}/{DATASET}_er_all_summary.json          # ER baselines + elapsed_s
+
+This module folds them into one long table with a ``level`` discriminator so the
+benchmark is queryable and renders in the HF Data Studio viewer:
+
+    level=summary      one row per (dataset, model, task, metric); ``value`` is the
+                       across-window mean, ``std`` its std where the source has one.
+    level=per_feature  MAE / RMSE per directly-follows relation (``feature``).
+    level=per_window   ER metrics per rolling ER window (``window``, ``n_traces``).
+
+Baselines that are identical across models within a (dataset, task) — the ground-truth
+DFG's ER (``truth_er``) and the training-window ER (``training_er``) — are emitted once
+as reference rows with ``model="reference"``.
+
+**Provenance:** point ``--outputs-dir`` at the canonical HPC (VSC) tree, which the repo
+syncs to ``data/hpc_sync/outputs/``. The top-level local ``outputs/`` is an independent
+run whose fine-tuned numbers differ; it is *not* the publishable source.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+DEFAULT_PROJECT = "pmf-tsfm"
+DEFAULT_PAPER = "arXiv:2512.07624"
+DEFAULT_OUTPUTS_DIR = "data/hpc_sync/outputs"
+TASKS: tuple[str, ...] = ("zero_shot", "lora_tune", "full_tune")
+
+# Fixed long-format schema. Every emitted row carries all of these keys.
+COLUMNS: list[str] = [
+    "project",
+    "paper",
+    "dataset",
+    "model",
+    "family",
+    "task",
+    "level",  # summary | per_feature | per_window
+    "metric",  # MAE | RMSE | pred_er | pred_fitting_ratio | truth_er | training_er
+    "value",
+    "std",
+    "feature",  # DF relation "A -> B" for per_feature rows
+    "window",  # ER window label for per_window rows
+    "n_traces",  # trace count for that ER window
+    "horizon",
+    "n_windows",
+    "n_features",
+    "runtime_s",  # ER elapsed_s (dataset-level); inference runtime is not on disk
+    "device",
+    "precision",
+    "context_length",
+    "base_model_id",
+    "seed",
+    "commit",  # repo commit the export was generated from
+]
+
+# ER metrics: metric name -> (mean key, std key or None) in the ER "summary" block.
+_ER_MODEL_METRICS = {
+    "pred_er": ("pred_er_mean", "pred_er_std"),
+    "pred_fitting_ratio": ("pred_fitting_ratio_mean", None),
+}
+_ER_REFERENCE_METRICS = {
+    "truth_er": ("truth_er_mean", "truth_er_std"),
+    "training_er": ("training_er_mean", "training_er_std"),
+}
+
+
+def normalize_dataset(name: str) -> str:
+    """Match the repo's config convention: dataset IDs are lowercase (``BPI2017`` -> ``bpi2017``)."""
+    return name.lower()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _finite(value: Any) -> bool:
+    """A real, usable number. Invalid ER windows carry ``pred_er: NaN`` in the source JSON."""
+    if value is None:
+        return False
+    if isinstance(value, float):
+        return math.isfinite(value)
+    return True
+
+
+def _std_or_none(value: Any) -> Any:
+    """Keep a std only if it is a finite number; otherwise drop it to null."""
+    return value if _finite(value) else None
+
+
+def _task_name(metadata: dict[str, Any], cfg: dict[str, Any]) -> str | None:
+    """Resolve the task to a string.
+
+    The top-level ``task`` is always the string id (``"lora_tune"``); ``config.task`` is
+    the task *config group* — a string in zero-shot but a nested dict in LoRA/full-tune.
+    """
+    top = metadata.get("task")
+    if isinstance(top, str):
+        return top
+    inner = cfg.get("task")
+    if isinstance(inner, dict):
+        return inner.get("name")
+    return inner if isinstance(inner, str) else None
+
+
+def _row(ctx: dict[str, Any], **overrides: Any) -> dict[str, Any]:
+    """Build a full row: every schema column present, ``None`` unless supplied."""
+    row = dict.fromkeys(COLUMNS)
+    for key in ("project", "paper", "dataset", "model", "family", "task", "commit"):
+        row[key] = ctx.get(key)
+    for key in (
+        "horizon",
+        "n_windows",
+        "n_features",
+        "device",
+        "precision",
+        "context_length",
+        "base_model_id",
+        "seed",
+    ):
+        if key in ctx:
+            row[key] = ctx[key]
+    row.update(overrides)
+    return row
+
+
+def run_context(metadata: dict[str, Any], *, dataset_fallback: str | None = None) -> dict[str, Any]:
+    """Extract the per-run context shared by every row of one run, from its metadata JSON."""
+    cfg = metadata.get("config", {})
+    model = cfg.get("model", {})
+    data = cfg.get("data", {})
+    dm = metadata.get("data_metadata", {})
+
+    dataset_name = data.get("name") or dm.get("dataset_name") or dataset_fallback or ""
+    return {
+        "dataset": normalize_dataset(dataset_name),
+        "model": model.get("name"),
+        "family": model.get("family"),
+        "task": _task_name(metadata, cfg),
+        "device": cfg.get("device"),
+        "precision": model.get("torch_dtype"),
+        "seed": cfg.get("seed"),
+        "context_length": cfg.get("context_length"),
+        "base_model_id": model.get("id"),
+        "horizon": cfg.get("prediction_length") or dm.get("prediction_length"),
+        "n_features": dm.get("num_features"),
+        "n_windows": dm.get("test_num_sequences"),
+    }
+
+
+def rows_from_metrics(metrics: dict[str, Any], ctx: dict[str, Any]) -> list[dict[str, Any]]:
+    """Summary (mean±std) and per-feature (per DF relation) MAE/RMSE rows."""
+    rows: list[dict[str, Any]] = []
+    summary = metrics.get("summary", {})
+    for metric in ("MAE", "RMSE"):
+        mean = summary.get(f"{metric}_mean")
+        if not _finite(mean):
+            continue
+        rows.append(
+            _row(
+                ctx,
+                level="summary",
+                metric=metric,
+                value=mean,
+                std=_std_or_none(summary.get(f"{metric}_std")),
+            )
+        )
+    for feature, values in metrics.get("per_feature", {}).items():
+        for metric in ("MAE", "RMSE"):
+            value = values.get(metric)
+            if not _finite(value):
+                continue
+            rows.append(_row(ctx, level="per_feature", metric=metric, value=value, feature=feature))
+    return rows
+
+
+def rows_from_er(er: dict[str, Any], ctx: dict[str, Any]) -> list[dict[str, Any]]:
+    """Per-model ER summary rows and per-window ER rows (pred_er, pred_fitting_ratio)."""
+    rows: list[dict[str, Any]] = []
+    summary = er.get("summary", {})
+    for metric, (mean_key, std_key) in _ER_MODEL_METRICS.items():
+        value = summary.get(mean_key)
+        if not _finite(value):
+            continue
+        std = _std_or_none(summary.get(std_key)) if std_key else None
+        rows.append(_row(ctx, level="summary", metric=metric, value=value, std=std))
+    for window in er.get("windows", []):
+        label = window.get("window")
+        n_traces = window.get("n_traces")
+        for metric in ("pred_er", "pred_fitting_ratio"):
+            value = window.get(metric)
+            if not _finite(value):
+                continue
+            rows.append(
+                _row(
+                    ctx,
+                    level="per_window",
+                    metric=metric,
+                    value=value,
+                    window=label,
+                    n_traces=n_traces,
+                )
+            )
+    return rows
+
+
+def reference_rows(er_all: dict[str, Any], ctx: dict[str, Any]) -> list[dict[str, Any]]:
+    """``truth_er`` / ``training_er`` baselines (identical across models) — emitted once."""
+    ref_ctx = {**ctx, "model": "reference", "family": "reference", "base_model_id": None}
+    runtime_s = er_all.get("elapsed_s")
+    n_windows = er_all.get("n_windows")
+    rows: list[dict[str, Any]] = []
+    for metric, (mean_key, std_key) in _ER_REFERENCE_METRICS.items():
+        value = er_all.get(mean_key)
+        if not _finite(value):
+            continue
+        rows.append(
+            _row(
+                ref_ctx,
+                level="summary",
+                metric=metric,
+                value=value,
+                std=_std_or_none(er_all.get(std_key)),
+                runtime_s=runtime_s,
+                n_windows=n_windows,
+            )
+        )
+    return rows
+
+
+def collect_rows(
+    outputs_dir: str | Path,
+    *,
+    tasks: tuple[str, ...] = TASKS,
+    project: str = DEFAULT_PROJECT,
+    paper: str = DEFAULT_PAPER,
+    commit: str | None = None,
+    exclude_models: tuple[str, ...] = (),
+) -> list[dict[str, Any]]:
+    """Walk ``outputs_dir`` and flatten every run into long-format rows.
+
+    ``exclude_models`` skips model directories by name (e.g. ``moirai_1_1_base``, which
+    the paper's 12 zero-shot variants omit). Dataset-level ER reference rows are kept
+    regardless of the model filter.
+    """
+    outputs_dir = Path(outputs_dir)
+    excluded = set(exclude_models)
+    stamp = {"project": project, "paper": paper, "commit": commit}
+    rows: list[dict[str, Any]] = []
+
+    for task in tasks:
+        task_dir = outputs_dir / task
+        if not task_dir.is_dir():
+            continue
+        for ds_dir in sorted(p for p in task_dir.iterdir() if p.is_dir()):
+            for model_dir in sorted(p for p in ds_dir.iterdir() if p.is_dir()):
+                if model_dir.name in excluded:
+                    continue
+                metrics_path = next(model_dir.glob("*_metrics.json"), None)
+                metadata_path = next(model_dir.glob("*_metadata.json"), None)
+                if metrics_path is None or metadata_path is None:
+                    continue
+                metrics = _load_json(metrics_path)
+                metadata = _load_json(metadata_path)
+
+                ctx = {**run_context(metadata, dataset_fallback=ds_dir.name), **stamp}
+                # metrics summary is authoritative for the shape counts
+                summary = metrics.get("summary", {})
+                if "num_sequences" in summary:
+                    ctx["n_windows"] = summary["num_sequences"]
+                if "num_features" in summary:
+                    ctx["n_features"] = summary["num_features"]
+                if "prediction_length" in summary:
+                    ctx["horizon"] = summary["prediction_length"]
+
+                rows.extend(rows_from_metrics(metrics, ctx))
+
+                er_path = (
+                    outputs_dir
+                    / "er"
+                    / task
+                    / ds_dir.name
+                    / model_dir.name
+                    / f"{ds_dir.name}_{model_dir.name}_er.json"
+                )
+                if er_path.exists():
+                    rows.extend(rows_from_er(_load_json(er_path), ctx))
+
+        # dataset-level ER baselines (once per dataset that has an ER aggregate)
+        er_task_dir = outputs_dir / "er" / task
+        if er_task_dir.is_dir():
+            for ds_dir in sorted(p for p in er_task_dir.iterdir() if p.is_dir()):
+                summary_path = ds_dir / f"{ds_dir.name}_er_all_summary.json"
+                if not summary_path.exists():
+                    continue
+                ref_ctx = {**stamp, "dataset": normalize_dataset(ds_dir.name), "task": task}
+                rows.extend(reference_rows(_load_json(summary_path), ref_ctx))
+
+    return rows
+
+
+def build_dataframe(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    """Assemble rows into a DataFrame with columns in the fixed schema order."""
+    return pd.DataFrame(rows, columns=COLUMNS)
+
+
+def _git_commit(repo_dir: Path) -> str | None:
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        out = subprocess.run(  # noqa: S603 — fixed argv, no shell, resolved git path
+            [git, "-C", str(repo_dir), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return out.stdout.strip() or None
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+
+
+def _summarize(df: pd.DataFrame) -> str:
+    by_level = df["level"].value_counts().to_dict()
+    n_runs = df[df["model"] != "reference"].groupby(["task", "dataset", "model"]).ngroups
+    return (
+        f"{len(df):,} rows from {n_runs} runs · "
+        f"levels: {by_level} · "
+        f"datasets: {sorted(df['dataset'].unique())} · "
+        f"tasks: {sorted(df['task'].dropna().unique())}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Normalize the outputs/ result tree into one long-format Parquet."
+    )
+    parser.add_argument(
+        "--outputs-dir",
+        default=DEFAULT_OUTPUTS_DIR,
+        help=f"Root of the result tree (default: {DEFAULT_OUTPUTS_DIR}, the canonical HPC sync).",
+    )
+    parser.add_argument(
+        "--out",
+        default="data/exports/pmf_tsfm_results.parquet",
+        help="Output Parquet path.",
+    )
+    parser.add_argument("--tasks", nargs="+", default=list(TASKS), help="Tasks to include.")
+    parser.add_argument("--project", default=DEFAULT_PROJECT)
+    parser.add_argument("--paper", default=DEFAULT_PAPER)
+    parser.add_argument(
+        "--commit",
+        default=None,
+        help="Provenance commit to stamp; defaults to the current repo's short HEAD.",
+    )
+    parser.add_argument("--csv", action="store_true", help="Also write a sibling .csv.")
+    parser.add_argument(
+        "--exclude-models",
+        nargs="*",
+        default=[],
+        metavar="MODEL",
+        help="Model dir names to skip (e.g. moirai_1_1_base to match the paper's 12 variants).",
+    )
+    args = parser.parse_args(argv)
+
+    commit = args.commit or _git_commit(Path(__file__).resolve().parent)
+    rows = collect_rows(
+        args.outputs_dir,
+        tasks=tuple(args.tasks),
+        project=args.project,
+        paper=args.paper,
+        commit=commit,
+        exclude_models=tuple(args.exclude_models),
+    )
+    df = build_dataframe(rows)
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    df.to_parquet(out, index=False)
+    print(f"Wrote {out}")
+    if args.csv:
+        csv_path = out.with_suffix(".csv")
+        df.to_csv(csv_path, index=False)
+        print(f"Wrote {csv_path}")
+    print(_summarize(df))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_export_hf_results.py
+++ b/tests/test_export_hf_results.py
@@ -1,0 +1,300 @@
+"""
+Tests for pmf_tsfm.export.hf_results — the results-dataset normalizer.
+
+Folds the nested per-(task, dataset, model) ``outputs/`` tree (metrics JSON,
+metadata JSON, ER JSON) into one long-format table with a ``level`` discriminator
+(summary / per_feature / per_window), ready to publish as an HF Dataset.
+
+Provenance note: the real exporter is pointed at ``data/hpc_sync/outputs/`` (the
+canonical VSC/HPC runs), never the top-level local ``outputs/`` tree. These tests
+build a tiny synthetic tree of the same shape.
+"""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pmf_tsfm.export.hf_results import (
+    COLUMNS,
+    build_dataframe,
+    collect_rows,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic outputs tree
+# ---------------------------------------------------------------------------
+
+
+def _write_json(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _metadata(dataset: str, model: str, task: str, *, family: str, dtype: str) -> dict:
+    # config.task is a plain string for zero-shot but the nested task-config group
+    # (a dict) for LoRA/full-tune runs — mirror that so the exporter is exercised on both.
+    config_task: object = task
+    if task != "zero_shot":
+        config_task = {"name": task, "context_mode": "fixed", "use_amp": True}
+    return {
+        "mode": f"{task.upper()} INFERENCE",
+        "task": task,
+        "config": {
+            "seed": 42,
+            "device": "cuda",
+            "context_length": 48,
+            "prediction_length": 7,
+            "task": config_task,
+            "model": {
+                "name": model,
+                "family": family,
+                "id": f"amazon/{model.replace('_', '-')}",
+                "variant": model,
+                "torch_dtype": dtype,
+            },
+            "data": {"name": dataset, "split_ratio": [0.6, 0.2, 0.2]},
+        },
+        "data_metadata": {
+            "dataset_name": dataset,
+            "num_features": 2,
+            "prediction_length": 7,
+            "test_num_sequences": 3,
+        },
+    }
+
+
+def _metrics() -> dict:
+    return {
+        "summary": {
+            "MAE_mean": 7.7,
+            "MAE_std": 8.6,
+            "RMSE_mean": 10.2,
+            "RMSE_std": 11.9,
+            "num_sequences": 3,
+            "num_features": 2,
+            "prediction_length": 7,
+        },
+        "per_feature": {
+            "A -> B": {"MAE": 1.0, "RMSE": 2.0},
+            "B -> ■": {"MAE": 3.0, "RMSE": 4.0},
+        },
+        "model_name": "chronos_bolt_small",
+        "dataset_name": "BPI2017",
+        "prediction_length": 7,
+    }
+
+
+def _er() -> dict:
+    return {
+        "summary": {
+            "model": "chronos_bolt_small",
+            "dataset": "BPI2017",
+            "task": "zero_shot",
+            "n_windows": 2,
+            "n_valid_windows": 2,
+            "truth_er_mean": 1.02,
+            "truth_er_std": 0.07,
+            "truth_fitting_ratio_mean": 1.0,
+            "pred_er_mean": 1.11,
+            "pred_er_std": 0.12,
+            "pred_fitting_ratio_mean": 0.99,
+            "training_er_mean": 1.17,
+            "training_er_std": 0.10,
+        },
+        "windows": [
+            {"window": "w1", "pred_er": 0.98, "pred_fitting_ratio": 0.999, "n_traces": 100},
+            {"window": "w2", "pred_er": 1.04, "pred_fitting_ratio": 0.997, "n_traces": 120},
+            # invalid window: ER undefined (source encodes pred_er as NaN), fitting_ratio 0
+            {"window": "w3", "pred_er": float("nan"), "pred_fitting_ratio": 0.0, "n_traces": 1},
+        ],
+    }
+
+
+def _er_all_summary() -> dict:
+    return {
+        "dataset": "BPI2017",
+        "task": "zero_shot",
+        "n_windows": 2,
+        "elapsed_s": 30.1,
+        "truth_er_mean": 1.02,
+        "truth_er_std": 0.07,
+        "training_er_mean": 1.17,
+        "training_er_std": 0.10,
+        "models": {},
+    }
+
+
+@pytest.fixture
+def outputs_tree(tmp_path) -> Path:
+    """A minimal ``outputs/`` tree: one zero-shot run (+ER) and one LoRA run (no ER)."""
+    root = tmp_path / "outputs"
+    ds, model = "BPI2017", "chronos_bolt_small"
+
+    # zero-shot run (has metrics + metadata + ER)
+    zs = root / "zero_shot" / ds / model
+    _write_json(zs / f"{ds}_{model}_metrics.json", _metrics())
+    _write_json(
+        zs / f"{ds}_{model}_metadata.json",
+        _metadata(ds, model, "zero_shot", family="chronos", dtype="float32"),
+    )
+    er_dir = root / "er" / "zero_shot" / ds / model
+    _write_json(er_dir / f"{ds}_{model}_er.json", _er())
+    _write_json(
+        root / "er" / "zero_shot" / ds / f"{ds}_er_all_summary.json",
+        _er_all_summary(),
+    )
+
+    # LoRA run (metrics + metadata only, no ER)
+    lt = root / "lora_tune" / ds / model
+    _write_json(lt / f"{ds}_{model}_metrics.json", _metrics())
+    _write_json(
+        lt / f"{ds}_{model}_metadata.json",
+        _metadata(ds, model, "lora_tune", family="chronos", dtype="float32"),
+    )
+    return root
+
+
+# ---------------------------------------------------------------------------
+# collect_rows
+# ---------------------------------------------------------------------------
+
+
+def test_every_row_has_the_exact_schema(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    assert rows, "expected at least some rows"
+    for row in rows:
+        assert set(row.keys()) == set(COLUMNS)
+
+
+def test_dataset_name_is_normalized_lowercase(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    assert {r["dataset"] for r in rows} == {"bpi2017"}
+
+
+def _one(rows, **filters):
+    hits = [r for r in rows if all(r.get(k) == v for k, v in filters.items())]
+    assert len(hits) == 1, f"expected exactly 1 row for {filters}, got {len(hits)}"
+    return hits[0]
+
+
+def test_summary_mae_row_carries_mean_std_and_context(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    row = _one(rows, task="zero_shot", level="summary", metric="MAE")
+    assert row["value"] == pytest.approx(7.7)
+    assert row["std"] == pytest.approx(8.6)
+    assert row["family"] == "chronos"
+    assert row["seed"] == 42
+    assert row["device"] == "cuda"
+    assert row["precision"] == "float32"
+    assert row["base_model_id"] == "amazon/chronos-bolt-small"
+    assert row["horizon"] == 7
+    assert row["n_windows"] == 3
+    assert row["n_features"] == 2
+    assert row["project"] == "pmf-tsfm"
+    assert row["paper"] == "arXiv:2512.07624"
+
+
+def test_per_feature_rows_preserve_relation_labels(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    pf = [r for r in rows if r["level"] == "per_feature" and r["task"] == "zero_shot"]
+    # 2 features x 2 metrics (MAE, RMSE)
+    assert len(pf) == 4
+    assert {r["feature"] for r in pf} == {"A -> B", "B -> ■"}
+    bb = _one(rows, task="zero_shot", level="per_feature", feature="A -> B", metric="RMSE")
+    assert bb["value"] == pytest.approx(2.0)
+    assert bb["std"] is None  # per-feature has no std
+
+
+def test_er_summary_and_per_window_rows(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    per = _one(
+        rows, task="zero_shot", level="summary", metric="pred_er", model="chronos_bolt_small"
+    )
+    assert per["value"] == pytest.approx(1.11)
+    assert per["std"] == pytest.approx(0.12)
+
+    windows = [r for r in rows if r["level"] == "per_window"]
+    # w1,w2 valid -> 2 x 2 metrics; w3 invalid -> only its finite fitting_ratio survives
+    assert len(windows) == 5
+    w1 = _one(rows, level="per_window", window="w1", metric="pred_er")
+    assert w1["value"] == pytest.approx(0.98)
+    assert w1["n_traces"] == 100
+
+
+def test_reference_rows_emitted_once_per_dataset(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    refs = [r for r in rows if r["model"] == "reference"]
+    metrics = sorted(r["metric"] for r in refs)
+    assert metrics == ["training_er", "truth_er"]
+    truth = _one(rows, model="reference", metric="truth_er")
+    assert truth["value"] == pytest.approx(1.02)
+    assert truth["std"] == pytest.approx(0.07)
+    assert truth["runtime_s"] == pytest.approx(30.1)  # ER elapsed_s lives at dataset level
+
+
+def test_task_resolves_to_string_even_when_config_task_is_a_dict(outputs_tree):
+    # LoRA/full-tune metadata carry config.task as the nested task-config dict; every
+    # emitted row's `task` must still be the string id (a dict would break Parquet).
+    rows = collect_rows(outputs_tree)
+    assert all(isinstance(r["task"], str) for r in rows)
+    assert {r["task"] for r in rows} == {"zero_shot", "lora_tune"}
+
+
+def test_lora_run_has_metrics_but_no_er_rows(outputs_tree):
+    rows = collect_rows(outputs_tree)
+    lora = [r for r in rows if r["task"] == "lora_tune"]
+    assert lora, "expected LoRA rows"
+    assert all(r["level"] in {"summary", "per_feature"} for r in lora)
+    assert all(r["metric"] in {"MAE", "RMSE"} for r in lora)
+    assert not any(r["level"] == "per_window" for r in lora)
+
+
+def test_commit_is_stamped_when_provided(outputs_tree):
+    rows = collect_rows(outputs_tree, commit="deadbee")
+    assert all(r["commit"] == "deadbee" for r in rows)
+
+
+def test_exclude_models_drops_that_model_but_keeps_reference_rows(outputs_tree):
+    rows = collect_rows(outputs_tree, exclude_models=("chronos_bolt_small",))
+    assert not any(r["model"] == "chronos_bolt_small" for r in rows)
+    # dataset-level ER baselines are independent of the model filter
+    assert any(r["model"] == "reference" for r in rows)
+
+
+def test_invalid_er_windows_are_dropped_so_value_is_never_null(outputs_tree):
+    # w3 has pred_er = NaN (invalid ER window); its pred_er row must not be emitted,
+    # keeping the "value is never null" invariant. Its finite fitting_ratio survives.
+    rows = collect_rows(outputs_tree)
+    assert all(r["value"] is not None for r in rows)
+    er_windows = {
+        r["window"] for r in rows if r["level"] == "per_window" and r["metric"] == "pred_er"
+    }
+    assert er_windows == {"w1", "w2"}
+    fit_windows = {
+        r["window"]
+        for r in rows
+        if r["level"] == "per_window" and r["metric"] == "pred_fitting_ratio"
+    }
+    assert "w3" in fit_windows  # fitting_ratio 0.0 is a real value, kept
+
+
+# ---------------------------------------------------------------------------
+# build_dataframe
+# ---------------------------------------------------------------------------
+
+
+def test_build_dataframe_has_columns_in_fixed_order(outputs_tree):
+    df = build_dataframe(collect_rows(outputs_tree))
+    assert list(df.columns) == COLUMNS
+    assert len(df) > 0
+
+
+def test_dataframe_roundtrips_through_parquet(outputs_tree, tmp_path):
+    df = build_dataframe(collect_rows(outputs_tree))
+    out = tmp_path / "results.parquet"
+    df.to_parquet(out, index=False)
+    back = pd.read_parquet(out)
+    assert list(back.columns) == COLUMNS
+    assert len(back) == len(df)


### PR DESCRIPTION
## What

Adds a results-dataset normalizer that folds the nested `outputs/` result tree
(per-(task, dataset, model) metrics + metadata + Entropic Relevance JSON) into one
long-format Parquet, ready to publish as a Hugging Face Dataset.

## Schema

23-column long format with a `level` discriminator so leaderboards and fine-grained
trajectories live in one table:

- `summary` — one row per (dataset, model, task, metric); `value` = mean, `std` where defined
- `per_feature` — MAE/RMSE per directly-follows relation
- `per_window` — Entropic Relevance per rolling ER window

`value` is never null: invalid ER windows (source `pred_er: NaN`) are dropped, and the
`truth_er`/`training_er` baselines — identical across models within a `(dataset, task)` —
are emitted once as `model="reference"` rows.

## Provenance

Sources the canonical **HPC (VSC)** tree at `data/hpc_sync/outputs/`, not the local
`outputs/` (fine-tuned numbers differ between the two independent runs). Default
`--outputs-dir` points there.

## Interface

```
pmf-export-results --outputs-dir <root> --out results.parquet [--csv] \
    [--exclude-models moirai_1_1_base]   # match the paper's 12 zero-shot variants
```

## Tests

13 new tests in `tests/test_export_hf_results.py` (schema, dict-shaped `config.task`,
NaN ER windows, reference rows, model filter, Parquet round-trip). Full suite green
(359 + 13 pass); ruff + format clean.

Ran against the HPC tree to produce the published dataset `YongboYu/pmf-tsfm-results`
(25,581 rows from 88 runs).
